### PR TITLE
Fix: load .env from package root, not process.cwd()

### DIFF
--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -7,12 +7,14 @@ import type { Implementation } from '@modelcontextprotocol/sdk/types.js';
 import { LocaleEnum } from '@/types/ebay-enums.js';
 import { getVersion } from '@/utils/version.js';
 
-// Load .env silently - suppress dotenv output to keep stdout clean for MCP JSON-RPC
-config({ quiet: true });
-
-// Get the current directory for loading scope files
+// Get the current directory for loading scope files and .env
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+
+// Load .env from the package root (two levels up from src/config/), not process.cwd().
+// MCP servers inherit cwd from the host (e.g. Claude Code's project dir), so
+// process.cwd() may point to an unrelated project with a different .env.
+config({ path: join(__dirname, '../../.env'), quiet: true });
 
 // Type for scope JSON structure
 interface ScopeDefinition {


### PR DESCRIPTION
## **User description**
## Summary
- MCP servers inherit `cwd` from the host application (e.g. Claude Code sets it to the active project directory)
- `dotenv`'s default `config()` loads from `process.cwd()`, so the server reads the **wrong `.env` file** when launched from a different directory
- This causes `EBAY_ENVIRONMENT` to default to `"sandbox"` and `EBAY_USER_REFRESH_TOKEN` to be missing — breaking all API calls with "client authentication failed"
- Fix: resolve `.env` relative to `__dirname` (the package's own `src/config/`) instead of `process.cwd()`

## Reproduction
1. Configure ebay-mcp as an MCP server in Claude Code (or any MCP host)
2. Open a project in a **different directory** that also has a `.env` file
3. All eBay API calls fail with "client authentication failed" because the server loaded the wrong `.env`

## Test plan
- [x] Verified fix resolves correct `.env` when `cwd` is a different project directory
- [x] Verified credentials, environment, and tokens all load correctly after fix
- [x] Verified eBay API calls succeed (Trading API ReviseFixedPriceItem)
- [x] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load .env from the package root (relative to __dirname) instead of process.cwd() so the MCP server always uses its own credentials. This fixes auth failures when launched from a different cwd (e.g., Claude Code), restoring correct EBAY_ENVIRONMENT and EBAY_USER_REFRESH_TOKEN.

<sup>Written for commit 529258334be9b13f70756ba684d1b153feeec7d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Load .env from package root so MCP server uses its own credentials**

### What Changed
- The server now loads .env from the package root (relative to the config folder) instead of using the process working directory.
- When launched from a different project directory, the MCP server no longer picks up unrelated .env values; EBAY_ENVIRONMENT and EBAY_USER_REFRESH_TOKEN are read from the package's .env.
- eBay API calls that previously failed with "client authentication failed" now succeed when correct credentials are present in the package .env.

### Impact
`✅ Restored eBay API authentication`
`✅ Fewer auth failures when MCP runs inside other projects`
`✅ Consistent environment variable loading`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment variable loading to consistently use the project root directory, improving configuration reliability in different execution contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->