### PR TITLE
fix(packaging): include build/mcp/**/*.js in published tarball

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Packaging** — Ship `build/mcp/**/*.js` in the published tarball. The architecture refactor in v1.8.9 moved runtime/HTTP transport into `src/mcp/`, but the `files` whitelist in `package.json` was not updated, so `npm install -g ebay-mcp@1.8.9` produced `ERR_MODULE_NOT_FOUND: Cannot find module '.../build/mcp/runtime.js'` at startup. ([#120](https://github.com/YosefHayim/ebay-mcp/issues/120))
+
 ### Changed
 
 - **API Status Docs** — Refreshed API status snapshot documentation in 5 post-`v1.8.5` pushes (`[skip ci]` docs-only updates)

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "build/api/**/*.js",
     "build/auth/**/*.js",
     "build/config/**/*.js",
+    "build/mcp/**/*.js",
     "build/schemas/**/*.js",
     "build/scripts/**/*.js",
     "build/tools/**/*.js",


### PR DESCRIPTION
## Summary

- Adds `build/mcp/**/*.js` to the `files` whitelist in `package.json` so the published npm tarball contains `runtime.js` and `http-transport.js`.
- v1.8.9 introduced `src/mcp/runtime.ts` and `src/mcp/http-transport.ts` (via the architecture-deepening refactor in #119) but never updated `files`, so `npm install -g ebay-mcp@1.8.9` produced `ERR_MODULE_NOT_FOUND` at startup.

Fixes #120.

## Test plan

- [x] `pnpm run build` succeeds
- [x] `npm pack --dry-run` shows `build/mcp/runtime.js` and `build/mcp/http-transport.js` in the tarball
- [x] `node build/index.js` starts without `ERR_MODULE_NOT_FOUND` (fails only on missing eBay credentials, as expected)
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` — 1005/1005 pass

Release workflow will bump to v1.8.10 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include `build/mcp/**/*.js` in the published npm tarball so `runtime.js` and `http-transport.js` are shipped. Updates the `package.json` `files` whitelist to stop startup failures (`ERR_MODULE_NOT_FOUND`) after installing `ebay-mcp` (fixes #120).

<sup>Written for commit 78804b01c08ab4d87d6a298127e28dde8fe3e957. Summary will update on new commits. <a href="https://cubic.dev/pr/YosefHayim/ebay-mcp/pull/121?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a module loading issue that occurred during package installation by ensuring all necessary distribution files are included in the published package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YosefHayim/ebay-mcp/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->