### PR TITLE
feat(cli): surface available update notices to users

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,7 @@ import { createEbayMcpRuntime, type EbayMcpRuntime } from '@/mcp/runtime.js';
 import { runSetup } from '@/scripts/setup.js';
 import { getErrorMessage } from '@/utils/errors.js';
 import { serverLogger, getLogPaths } from '@/utils/logger.js';
-import { checkForUpdates } from '@/utils/version.js';
-
-checkForUpdates({ defer: true });
+import { getCachedUpdateNotice } from '@/utils/version.js';
 
 const args = process.argv.slice(2);
 if (args.includes('setup')) {
@@ -49,6 +47,13 @@ class EbayMcpServer {
 
   async run(): Promise<void> {
     serverLogger.info('Starting eBay API MCP Server');
+
+    // stdout is reserved for the MCP protocol, so a TTY update box (used by the
+    // CLIs) can't run here — surface any newer version as a stderr log line.
+    const updateNotice = getCachedUpdateNotice();
+    if (updateNotice) {
+      serverLogger.info(updateNotice);
+    }
 
     // Validate environment configuration
     const validation = validateEnvironmentConfig();

--- a/src/scripts/diagnostics.ts
+++ b/src/scripts/diagnostics.ts
@@ -18,6 +18,7 @@ import { displayScopeVerification, parseScopeString } from '../utils/scope-helpe
 import { readEnvironment } from './setup-shared.js';
 import { EbaySellerApi } from '../api/index.js';
 import { getErrorMessage } from '@/utils/errors.js';
+import { getUpdateInfo, getVersion } from '@/utils/version.js';
 import type { EbayConfig } from '../types/ebay.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -116,6 +117,35 @@ function displaySystemInfo(): void {
   console.log(`  ${chalk.gray('Platform:')} ${process.platform}`);
   console.log(`  ${chalk.gray('Architecture:')} ${process.arch}`);
   console.log(`  ${chalk.gray('CWD:')} ${process.cwd()}`);
+  console.log('');
+}
+
+/**
+ * Check npm for a newer published version and surface it. `diagnose` is an
+ * intentional, interactive command run by the user, so a live registry fetch is
+ * appropriate here (unlike the server hot path, which uses the cached check).
+ * A failed fetch (offline) is reported, not thrown — diagnostics should never
+ * abort on a best-effort network call.
+ */
+async function displayUpdateStatus(): Promise<void> {
+  console.log(chalk.bold.cyan('🔄 Version\n'));
+  console.log(`  ${chalk.gray('Installed:')} ${getVersion()}`);
+
+  try {
+    const info = await getUpdateInfo();
+    if (info) {
+      console.log(
+        `  ${chalk.gray('Latest:')}    ${chalk.green(info.latest)} ${chalk.yellow(`(run \`npm i -g ${info.name}\` to update)`)}`
+      );
+    } else {
+      console.log(`  ${chalk.gray('Latest:')}    ${chalk.green('up to date')}`);
+    }
+  } catch {
+    console.log(
+      `  ${chalk.gray('Latest:')}    ${chalk.dim('update check unavailable (offline?)')}`
+    );
+  }
+
   console.log('');
 }
 
@@ -271,6 +301,7 @@ async function generateDiagnosticReport(exportPath?: string): Promise<Diagnostic
 async function runDiagnostics(exportReport = false): Promise<void> {
   displayHeader();
   displaySystemInfo();
+  await displayUpdateStatus();
 
   // Security checks
   const securityResults = await runSecurityChecks(PROJECT_ROOT);

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -66,7 +66,16 @@ export function getPackageName(): string {
 const ONE_DAY_MS = 1000 * 60 * 60 * 24;
 
 /**
- * Notifies global CLI users when a newer package version is available.
+ * Surface a "newer version available" box in an interactive terminal — the
+ * setup wizard and `diagnose`.
+ *
+ * `shouldNotifyInNpmScript: true` is essential: these CLIs are launched via
+ * `npm run setup` / `npx`, and without this flag update-notifier suppresses the
+ * notice whenever it detects an npm/yarn user agent (the common case). The
+ * notice is still a no-op when stdout is not a TTY (e.g. the MCP server's piped
+ * stdio); that path uses {@link getCachedUpdateNotice} instead. Dropping the
+ * old custom `message` lets update-notifier render its default colorized
+ * template (dim current → green latest, cyan command).
  */
 export function checkForUpdates(options: { defer?: boolean } = {}): void {
   const pkg = getPackageJson();
@@ -74,14 +83,41 @@ export function checkForUpdates(options: { defer?: boolean } = {}): void {
   const notifier = updateNotifier({
     pkg,
     updateCheckInterval: ONE_DAY_MS,
+    shouldNotifyInNpmScript: true,
   });
 
   notifier.notify({
     isGlobal: true,
     defer: options.defer ?? false,
-    message:
-      'Update available {currentVersion} → {latestVersion}\n' + 'Run {updateCommand} to update',
   });
+}
+
+/**
+ * Build a one-line "update available" notice from update-notifier's cached
+ * daily check, for contexts with no TTY where {@link checkForUpdates} stays
+ * silent — chiefly the MCP server, whose stdout is reserved for the protocol so
+ * the notice must go to a stderr log line instead of a box.
+ *
+ * Constructing the notifier triggers the once-a-day background check and reads
+ * its cached result, so this never blocks startup or hits the network on the
+ * hot path. Returns `undefined` when already current, or before the first
+ * background check has populated the cache (so the notice appears from the
+ * second run onward — update-notifier's normal behavior).
+ */
+export function getCachedUpdateNotice(): string | undefined {
+  const pkg = getPackageJson();
+
+  const notifier = updateNotifier({
+    pkg,
+    updateCheckInterval: ONE_DAY_MS,
+  });
+
+  const { update } = notifier;
+  if (!update || update.latest === pkg.version) {
+    return undefined;
+  }
+
+  return `Update available ${pkg.version} → ${update.latest} — run \`npm i -g ${pkg.name}\` to update`;
 }
 
 /**

--- a/tests/unit/utils/version.test.ts
+++ b/tests/unit/utils/version.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for the version / update-notifier helpers.
+ *
+ * The behavior under test is the wiring that makes "a new version is available"
+ * actually reach users: `checkForUpdates` must opt into npm-script contexts
+ * (our CLIs run via `npm run setup` / `npx`, which update-notifier otherwise
+ * silences), `getCachedUpdateNotice` must turn the cached check into a plain
+ * stderr-safe line for the MCP server (no TTY box there), and `getUpdateInfo`
+ * must report a newer version only when one exists. update-notifier is mocked
+ * so no real registry request or background process is spawned.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const notify = vi.fn();
+const fetchInfo = vi.fn();
+
+/** Mutable state the mocked notifier exposes; reset before each test. */
+let mockUpdate: { latest: string; current?: string } | undefined;
+let lastConstructorOptions: { shouldNotifyInNpmScript?: boolean; updateCheckInterval?: number };
+
+vi.mock('update-notifier', () => ({
+  default: (options: { shouldNotifyInNpmScript?: boolean; updateCheckInterval?: number }) => {
+    lastConstructorOptions = options;
+    return { notify, fetchInfo, update: mockUpdate };
+  },
+}));
+
+import {
+  checkForUpdates,
+  getCachedUpdateNotice,
+  getUpdateInfo,
+  getVersion,
+} from '@/utils/version.js';
+
+const CURRENT = getVersion();
+
+beforeEach(() => {
+  mockUpdate = undefined;
+  lastConstructorOptions = {};
+  notify.mockClear();
+  fetchInfo.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('checkForUpdates', () => {
+  it('opts into npm-script contexts so `npm run setup` is not silenced', () => {
+    checkForUpdates();
+
+    expect(lastConstructorOptions.shouldNotifyInNpmScript).toBe(true);
+    expect(notify).toHaveBeenCalledWith(expect.objectContaining({ isGlobal: true, defer: false }));
+  });
+
+  it('forwards the defer flag for the long-lived server context', () => {
+    checkForUpdates({ defer: true });
+
+    expect(notify).toHaveBeenCalledWith(expect.objectContaining({ defer: true }));
+  });
+});
+
+describe('getCachedUpdateNotice', () => {
+  it('returns a one-line notice when a newer version is cached', () => {
+    mockUpdate = { latest: '99.0.0' };
+
+    const notice = getCachedUpdateNotice();
+
+    expect(notice).toBe(`Update available ${CURRENT} → 99.0.0 — run \`npm i -g ebay-mcp\` to update`);
+  });
+
+  it('returns undefined before the cache is populated (first run)', () => {
+    mockUpdate = undefined;
+
+    expect(getCachedUpdateNotice()).toBeUndefined();
+  });
+
+  it('returns undefined when already on the latest version', () => {
+    mockUpdate = { latest: CURRENT };
+
+    expect(getCachedUpdateNotice()).toBeUndefined();
+  });
+});
+
+describe('getUpdateInfo', () => {
+  it('reports current/latest/name when a newer version exists', async () => {
+    mockUpdate = { latest: '99.0.0' };
+
+    const info = await getUpdateInfo();
+
+    expect(fetchInfo).toHaveBeenCalled();
+    expect(info).toEqual({ current: CURRENT, latest: '99.0.0', name: 'ebay-mcp' });
+  });
+
+  it('returns undefined when the latest version equals the current one', async () => {
+    mockUpdate = { latest: CURRENT };
+
+    expect(await getUpdateInfo()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## **User description**
## What & why

`update-notifier` was already a dependency but **dormant** — users were never told when a newer `ebay-mcp` shipped. Three gaps:

1. The notice was silenced in npm-script contexts (`npm run setup` / `npx`), which is the common launch path for the CLIs.
2. `getUpdateInfo()` existed but was never called.
3. The MCP server has no TTY, so a boxed notice can't render there.

This PR makes "a newer version is available" actually reach users across all three surfaces.

## Changes

- **`src/utils/version.ts`** — `checkForUpdates()` now sets `shouldNotifyInNpmScript: true` so the setup wizard / `diagnose` show update-notifier's default colorized box; dropped the old custom plain-text message. Added `getCachedUpdateNotice()` for no-TTY callers.
- **`src/index.ts`** — emits a one-line **stderr** update notice on server start (stdout stays reserved for the MCP protocol), backed by the cached daily check so startup never blocks on the network.
- **`src/scripts/diagnostics.ts`** — new **Version** section in `diagnose` with a live registry check (installed vs latest), failing soft when offline.
- **`tests/unit/utils/version.test.ts`** — covers the notifier wiring with `update-notifier` mocked (no real registry hit / background process).

## What users will see

Setup wizard / `npm run setup`:
```
   ╭──────────────────────────────────────╮
   │   Update available 1.9.0 → 1.10.0    │
   │   Run npm i -g ebay-mcp to update    │
   ╰──────────────────────────────────────╯
```
`diagnose`:
```
🔄 Version
  Installed: 1.9.0
  Latest:    1.10.0 (run `npm i -g ebay-mcp` to update)
```
MCP server startup (stderr log):
```
[INFO] [Server] Update available 1.9.0 → 1.10.0 — run `npm i -g ebay-mcp` to update
```

## Validation

- `npm run check` — 0 errors (593 baseline warnings)
- `npm test` — **1042 passed** (+7 new)
- `npm run build` — clean

Backward-compatible UX improvement → labelled `minor` (→ v1.10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces version update notices across the CLI and server so users know when a newer `ebay-mcp` is available. Notices appear in `npm run`/`npx`, in `diagnose`, and as a one-line server log without blocking startup.

- **New Features**
  - Show `update-notifier` box in npm-script contexts (`shouldNotifyInNpmScript: true`).
  - Add `getCachedUpdateNotice()` and log a one-line update on server start (cached daily check; no network on hot path).
  - Add a Version section to `diagnose` with a live registry check; soft-fails when offline.
  - Add unit tests for the notifier wiring with `update-notifier` mocked.

<sup>Written for commit f5f0c1733949e12106e247ed854b599df7be6ed8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YosefHayim/ebay-mcp/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Show available update notices in the CLI, diagnostics, and server logs**

### What Changed
- The setup flow and other interactive CLI commands now show the standard “new version available” notice when a newer release exists.
- `diagnose` now includes a Version section that shows the installed version, the latest published version, and an update command; if the network check fails, it shows an offline/unavailable message instead of stopping.
- The MCP server now writes a short update notice to stderr when a newer version is already known, so users can see it without breaking the protocol output.
- The version helper behavior is covered by tests for update notices, version checks, and the npm-script case.

### Impact
`✅ Update prompts visible during setup`
`✅ Clearer version checks in diagnose`
`✅ Update notice shown without disrupting server output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
