### PR TITLE
ci: upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/api-status-sync.yml
+++ b/.github/workflows/api-status-sync.yml
@@ -14,13 +14,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'pnpm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'pnpm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,16 +62,16 @@ jobs:
           esac
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.ref.outputs.ref }}
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,17 +23,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -166,7 +166,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.skip_check.outputs.skip != 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: ${{ steps.version.outputs.tag }} - ${{ steps.desc.outputs.title }}

--- a/.github/workflows/weekly-api-sync.yml
+++ b/.github/workflows/weekly-api-sync.yml
@@ -20,10 +20,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'pnpm'

--- a/.github/workflows/weekly-cleanup.yml
+++ b/.github/workflows/weekly-cleanup.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch all history to ensure we can see all runs
           fetch-depth: 0

--- a/.github/workflows/weekly-unit-tests.yml
+++ b/.github/workflows/weekly-unit-tests.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'pnpm'


### PR DESCRIPTION
## Why

GitHub will **force Node 24** on Actions runners starting **2026-06-16** and is already warning that the Node 20-based actions used in our workflows may stop working ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The v1.10.0 release run surfaced this annotation.

## What

Bump every affected action to its current Node 24-based major, across **all** workflows (not just release/publish):

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | **v6** |
| `pnpm/action-setup` | v4 | **v6** |
| `actions/setup-node` | v4 | **v6** |
| `softprops/action-gh-release` | v2 | **v3** |

No `with:` input changes are needed — every key in use is still supported. `pnpm/action-setup@v6` resolves the pnpm version from `package.json`'s `packageManager: pnpm@10.14.0` (no `version:` input required). `checkout@v6` was already in use by `weekly-api-sync.yml`, so it's proven on this repo's runners. The `ci.yml` run on this PR exercises the upgraded checkout/pnpm/setup-node trio directly.

## Release impact

None — this is CI infrastructure only and does not change the published package, so it's labelled **`no-release`** to avoid a pointless version bump / republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade all GitHub Actions in all workflows to Node 24–compatible majors ahead of GitHub’s Node 24 runner switch on 2026-06-16. No workflow input changes; CI only with no package or release impact.

- **Dependencies**
  - `actions/checkout`: v4 → v6
  - `pnpm/action-setup`: v4 → v6 (pnpm version auto-resolved from `packageManager`)
  - `actions/setup-node`: v4 → v6
  - `softprops/action-gh-release`: v2 → v3

<sup>Written for commit a897b540384afe19639234573a09064a5d07a938. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YosefHayim/ebay-mcp/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

