### PR TITLE
feat(tools): gate tool exposure via EBAY_MCP_TOOLS to control agent context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ Other useful scripts:
 - Validate tool inputs with Zod; derive related schemas rather than duplicating fields.
 - Commit with [Conventional Commits](https://www.conventionalcommits.org/) (releases are changeset-driven).
 - Logs go to **stderr** only (stdout is reserved for the MCP protocol) — see [docs/logging.md](docs/logging.md).
+- **Tool exposure** is gated by `EBAY_MCP_TOOLS` (`all` | `dynamic` | family list). The env parsing/validation lives in `src/config/tool-families.ts` (kept free of tool-tree imports to avoid a cycle with `config/environment.ts`); the dynamic-mode discovery meta-tools and catalogue live in `src/mcp/tool-gating.ts`; `src/mcp/runtime.ts` applies the mode. Family keys must stay in sync with `toolCategories` (a unit test enforces this).
 
 ## Agent skills
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,20 @@ EBAY_MARKETPLACE_ID=EBAY_US         # default marketplace (overridable per tool)
 EBAY_CONTENT_LANGUAGE=en-US         # default request content language
 EBAY_USER_REFRESH_TOKEN=your_token  # for higher rate limits
 EBAY_MCP_UI=on                      # interactive MCP Apps views (beta); "off" forces plain JSON
+EBAY_MCP_TOOLS=all                  # tool exposure: "all", "dynamic", or a family list (see below)
 ```
+
+### Tool exposure (`EBAY_MCP_TOOLS`)
+
+By default all tools are advertised to the agent at once. On a long conversation that catalogue is a meaningful slice of the context window, so two opt-in modes let you shrink it:
+
+| Value                       | Behavior                                                                                                                                               | Works on                                |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `all` _(default, or unset)_ | Every tool advertised at startup.                                                                                                                      | every host                              |
+| `dynamic`                   | Only three discovery tools are visible (`list_ebay_tools`, `enable_ebay_tools`, `disable_ebay_tools`). The agent searches the catalogue and loads only the tools it needs; they then appear natively. | hosts that honor `tools/listChanged` (e.g. Claude) |
+| `inventory,fulfillment,…`   | Registers **only** the named families (listed below), frozen for the session.                                                                          | every host (incl. ChatGPT, Cursor)      |
+
+The family list is literal — you get exactly what you name. ChatGPT connectors need the `connector` family (its `search`/`fetch` tools); add it explicitly, e.g. `EBAY_MCP_TOOLS=connector,inventory`. An unknown family name fails fast at startup with the valid list. Valid families: `connector`, `token-management`, `account`, `inventory`, `fulfillment`, `marketing`, `analytics`, `metadata`, `taxonomy`, `communication`, `other`, `developer`, `trading`.
 
 ### Authentication & rate limits
 

--- a/docs/auth/CONFIGURATION.md
+++ b/docs/auth/CONFIGURATION.md
@@ -87,6 +87,17 @@ These credentials are obtained from the [eBay Developer Portal](https://develope
 - **Default:** `en-US`
 - **Behavior:** Sent on all requests; defaults to `en-US` if unset. Per-tool overrides are not currently exposed.
 
+#### `EBAY_MCP_TOOLS`
+
+- **Description:** Controls how many tools the server advertises to the agent, to manage context-window usage
+- **Example:** `all`, `dynamic`, `inventory,fulfillment`
+- **Required:** No (optional)
+- **Default:** `all`
+- **Behavior:**
+  - `all` (or unset) — every tool is advertised at startup (original behavior).
+  - `dynamic` — only three discovery tools are advertised (`list_ebay_tools`, `enable_ebay_tools`, `disable_ebay_tools`); the agent searches the catalogue and enables tools on demand, which then appear natively. Requires a host that honors `tools/listChanged` (e.g. Claude); not suitable for hosts that ignore it.
+  - A comma-separated family list — registers **only** those families, frozen for the session; works on every host. The list is literal (ChatGPT connectors must include `connector`). Valid families: `connector`, `token-management`, `account`, `inventory`, `fulfillment`, `marketing`, `analytics`, `metadata`, `taxonomy`, `communication`, `other`, `developer`, `trading`. An unknown family name fails validation at startup.
+
 ### Required: User Refresh Token (For OAuth Flow)
 
 #### `EBAY_USER_REFRESH_TOKEN`

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'path';
 import type { EbayConfig } from '@/types/ebay.js';
 import type { Implementation } from '@modelcontextprotocol/sdk/types.js';
 import { LocaleEnum } from '@/types/ebay-enums.js';
+import { getToolGatingConfigError } from '@/config/tool-families.js';
 import { getVersion } from '@/utils/version.js';
 import { getErrorMessage } from '@/utils/errors.js';
 
@@ -164,6 +165,12 @@ export function validateEnvironmentConfig(): {
     warnings.push(
       'EBAY_REDIRECT_URI is not set. User OAuth flow will not work. Set this to enable user token generation.'
     );
+  }
+
+  // Validate EBAY_MCP_TOOLS (all | dynamic | comma-separated family list)
+  const toolGatingError = getToolGatingConfigError();
+  if (toolGatingError) {
+    errors.push(toolGatingError);
   }
 
   // Validate that scope files exist

--- a/src/config/tool-families.ts
+++ b/src/config/tool-families.ts
@@ -1,0 +1,104 @@
+/**
+ * Tool-family contract for the `EBAY_MCP_TOOLS` env var.
+ *
+ * This module is deliberately free of any import from the tool tree
+ * (`@/tools/*`). `config/environment.ts` validates `EBAY_MCP_TOOLS` and is itself
+ * imported by tool handlers (e.g. `tools/categories/token-management.ts`), so
+ * pulling the registry in here would create an import cycle. The heavier pieces
+ * that genuinely need the registry — the discovery catalogue and the meta-tools —
+ * live in `@/mcp/tool-gating.ts`, which imports these primitives.
+ *
+ * The family keys below must stay in lock-step with `toolCategories`; a unit test
+ * asserts the two agree so adding a category without updating this list fails CI.
+ */
+
+/**
+ * Canonical tool-family keys, mirroring `toolCategories[].key`. These are the
+ * accepted tokens in a static `EBAY_MCP_TOOLS` list (e.g. `inventory,fulfillment`).
+ */
+export const TOOL_FAMILY_KEYS = [
+  'connector',
+  'token-management',
+  'account',
+  'inventory',
+  'fulfillment',
+  'marketing',
+  'analytics',
+  'metadata',
+  'taxonomy',
+  'communication',
+  'other',
+  'developer',
+  'trading',
+] as const;
+
+/** A valid tool-family key. */
+export type ToolFamilyKey = (typeof TOOL_FAMILY_KEYS)[number];
+
+const FAMILY_KEY_SET: ReadonlySet<string> = new Set(TOOL_FAMILY_KEYS);
+
+/**
+ * How the server gates which tools it advertises, resolved from `EBAY_MCP_TOOLS`:
+ *
+ * - `all` — every tool advertised at boot (the default; unset behaves as `all`).
+ * - `dynamic` — only the discovery meta-tools are advertised; the agent enables
+ *   eBay tools on demand (requires a host that honours `tools/listChanged`).
+ * - `static` — only the named families are registered, frozen for the session;
+ *   works on every host, including those that ignore `listChanged`.
+ */
+export type ToolGatingMode =
+  | { kind: 'all' }
+  | { kind: 'dynamic' }
+  | { kind: 'static'; families: ToolFamilyKey[] };
+
+/** Splits a raw `EBAY_MCP_TOOLS` list into trimmed, lowercased, non-empty tokens. */
+function parseFamilyTokens(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/**
+ * Resolves `EBAY_MCP_TOOLS` into a {@link ToolGatingMode}.
+ *
+ * Parsing is lenient by design — unknown family tokens are kept in the returned
+ * `static` mode so the dedicated validator ({@link getToolGatingConfigError}) can
+ * report them precisely. Callers that act on the mode should treat only
+ * {@link TOOL_FAMILY_KEYS} members as registerable.
+ */
+export function resolveToolGatingMode(env: NodeJS.ProcessEnv = process.env): ToolGatingMode {
+  const raw = env.EBAY_MCP_TOOLS?.trim();
+  if (!raw || raw.toLowerCase() === 'all') {
+    return { kind: 'all' };
+  }
+  if (raw.toLowerCase() === 'dynamic') {
+    return { kind: 'dynamic' };
+  }
+  return { kind: 'static', families: parseFamilyTokens(raw) as ToolFamilyKey[] };
+}
+
+/**
+ * Validates `EBAY_MCP_TOOLS` and returns a human-readable error string, or
+ * `undefined` when the value is valid. Surfaced through
+ * `validateEnvironmentConfig` so a typo fails loudly at startup (server exits)
+ * rather than silently leaving the agent with fewer tools than intended.
+ */
+export function getToolGatingConfigError(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const mode = resolveToolGatingMode(env);
+  if (mode.kind !== 'static') {
+    return undefined;
+  }
+
+  if (mode.families.length === 0) {
+    return `EBAY_MCP_TOOLS is set but lists no tool families. Use "all", "dynamic", or a comma-separated list of: ${TOOL_FAMILY_KEYS.join(', ')}.`;
+  }
+
+  const unknown = mode.families.filter((family) => !FAMILY_KEY_SET.has(family));
+  if (unknown.length === 0) {
+    return undefined;
+  }
+
+  const noun = unknown.length === 1 ? 'family' : 'families';
+  return `EBAY_MCP_TOOLS contains unknown tool ${noun}: ${unknown.join(', ')}. Valid families: ${TOOL_FAMILY_KEYS.join(', ')}.`;
+}

--- a/src/config/tool-families.ts
+++ b/src/config/tool-families.ts
@@ -45,11 +45,16 @@ const FAMILY_KEY_SET: ReadonlySet<string> = new Set(TOOL_FAMILY_KEYS);
  *   eBay tools on demand (requires a host that honours `tools/listChanged`).
  * - `static` — only the named families are registered, frozen for the session;
  *   works on every host, including those that ignore `listChanged`.
+ *
+ * The `static` variant's `families` is intentionally `string[]`, not
+ * `ToolFamilyKey[]`: parsing is lenient and may carry unknown tokens until
+ * {@link getToolGatingConfigError} validates them. Typing it as the narrowed key
+ * would advertise a guarantee the value does not yet hold.
  */
 export type ToolGatingMode =
   | { kind: 'all' }
   | { kind: 'dynamic' }
-  | { kind: 'static'; families: ToolFamilyKey[] };
+  | { kind: 'static'; families: string[] };
 
 /** Splits a raw `EBAY_MCP_TOOLS` list into trimmed, lowercased, non-empty tokens. */
 function parseFamilyTokens(raw: string): string[] {
@@ -75,7 +80,7 @@ export function resolveToolGatingMode(env: NodeJS.ProcessEnv = process.env): Too
   if (raw.toLowerCase() === 'dynamic') {
     return { kind: 'dynamic' };
   }
-  return { kind: 'static', families: parseFamilyTokens(raw) as ToolFamilyKey[] };
+  return { kind: 'static', families: parseFamilyTokens(raw) };
 }
 
 /**

--- a/src/mcp/runtime.ts
+++ b/src/mcp/runtime.ts
@@ -1,7 +1,14 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServer, type RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { Implementation } from '@modelcontextprotocol/sdk/types.js';
 import { EbaySellerApi } from '@/api/index.js';
 import { getEbayConfig, mcpConfig } from '@/config/environment.js';
+import { resolveToolGatingMode } from '@/config/tool-families.js';
+import {
+  createToolGatingController,
+  DYNAMIC_MODE_INSTRUCTIONS,
+  registerMetaTools,
+  toolNamesInFamilies,
+} from '@/mcp/tool-gating.js';
 import { buildUiToolResult, createUiBridge, type UiBridge } from '@/mcp/ui-bridge.js';
 import { getToolEntries, type ToolEntry } from '@/tools/registry.js';
 import { getErrorMessage } from '@/utils/errors.js';
@@ -58,7 +65,7 @@ function registerTool(
   entry: ToolEntry,
   logToolExecution: boolean,
   ui: UiBridge
-): void {
+): RegisteredTool {
   const { definition, handler } = entry;
 
   // Registered plainly (no UI `_meta`) so every host gets a working text tool by
@@ -97,6 +104,7 @@ function registerTool(
   );
 
   ui.register(entry, registered);
+  return registered;
 }
 
 /**
@@ -104,14 +112,55 @@ function registerTool(
  */
 export function createEbayMcpRuntime(options: EbayMcpRuntimeOptions = {}): EbayMcpRuntime {
   const api = options.api ?? new EbaySellerApi(getEbayConfig());
-  const server = new McpServer(options.serverConfig ?? mcpConfig);
-  const entries = getToolEntries();
+  const serverInfo = options.serverConfig ?? mcpConfig;
+  const mode = resolveToolGatingMode();
+
+  // Instructions are set only in dynamic mode so the agent knows the catalogue is
+  // hidden behind the discovery tools; default/static modes keep the handshake
+  // byte-for-byte unchanged (a bare single-arg construction).
+  const server =
+    mode.kind === 'dynamic'
+      ? new McpServer(serverInfo, { instructions: DYNAMIC_MODE_INSTRUCTIONS })
+      : new McpServer(serverInfo);
+
   const ui = createUiBridge(server, import.meta.url);
 
-  serverLogger.info(`Registering ${entries.length} tools`);
+  // Static mode registers only the named families; all and dynamic register the
+  // full catalogue (dynamic then disables it below, before the transport connects).
+  const allEntries = getToolEntries();
+  const entries =
+    mode.kind === 'static'
+      ? (() => {
+          const names = toolNamesInFamilies(mode.families);
+          return allEntries.filter((entry) => names.has(entry.definition.name));
+        })()
+      : allEntries;
 
+  const handles = new Map<string, RegisteredTool>();
   for (const entry of entries) {
-    registerTool(server, api, entry, options.logToolExecution ?? false, ui);
+    handles.set(
+      entry.definition.name,
+      registerTool(server, api, entry, options.logToolExecution ?? false, ui)
+    );
+  }
+
+  if (mode.kind === 'dynamic') {
+    // Disable before `connect`: the SDK only emits `tools/listChanged` once the
+    // transport is connected, so these flips are silent. The agent re-enables the
+    // tools it needs via the meta-tools, which fire `listChanged` post-connect.
+    for (const handle of handles.values()) {
+      handle.disable();
+    }
+    registerMetaTools(server, createToolGatingController(handles));
+    serverLogger.info(
+      `Dynamic tool mode: ${handles.size} eBay tools hidden behind 3 discovery tools`
+    );
+  } else if (mode.kind === 'static') {
+    serverLogger.info(
+      `Static tool mode: registered ${handles.size} tools from families: ${mode.families.join(', ')}`
+    );
+  } else {
+    serverLogger.info(`Registering ${handles.size} tools`);
   }
 
   // Install after registration so every UI-eligible tool is captured before the

--- a/src/mcp/tool-gating.ts
+++ b/src/mcp/tool-gating.ts
@@ -1,0 +1,286 @@
+import { z } from 'zod';
+import type { McpServer, RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { TOOL_FAMILY_KEYS } from '@/config/tool-families.js';
+import { toolCategories } from '@/tools/categories/index.js';
+
+/**
+ * Tool gating: the runtime half of the `EBAY_MCP_TOOLS=dynamic` feature.
+ *
+ * In dynamic mode the server registers every eBay tool but boots with them
+ * disabled, advertising only the three discovery meta-tools defined here. The
+ * agent browses the catalogue and enables just the tools it needs; the MCP SDK
+ * emits `tools/listChanged` automatically when a tool's `enabled` flag flips, so
+ * the host re-fetches and the freshly enabled tools appear natively, with their
+ * real input schemas and validation. This keeps advertised context proportional
+ * to what the agent actually uses instead of the full ~187-tool catalogue.
+ *
+ * The pure env parsing/validation lives in `@/config/tool-families.ts`; this
+ * module owns everything that needs the live tool registry.
+ */
+
+/** Default page size for {@link ToolGatingController.list} when `limit` is omitted. */
+const DEFAULT_LIST_LIMIT = 25;
+
+/** Upper bound on a single discovery page, mirrored by the `list_ebay_tools` schema. */
+const MAX_LIST_LIMIT = 100;
+
+/**
+ * Initialize-time guidance shown to the agent in dynamic mode so it knows the
+ * catalogue is hidden behind the discovery tools. Set only when dynamic mode is
+ * active; the default and static modes leave the handshake untouched.
+ */
+export const DYNAMIC_MODE_INSTRUCTIONS =
+  'This eBay server keeps its full tool catalogue hidden to save context. Only the discovery tools are visible right now. ' +
+  'Call `list_ebay_tools` (no arguments) to see the tool families, then `list_ebay_tools` with a `family` or `query` to find specific tools, ' +
+  'then `enable_ebay_tools` with the tool names you need — they will appear as normal tools you can call. ' +
+  'Call `disable_ebay_tools` to remove tools you no longer need and reclaim context.';
+
+/** One discoverable eBay tool — lightweight by design; the full input schema arrives only on enable. */
+interface ToolCatalogRow {
+  name: string;
+  family: string;
+  summary: string;
+}
+
+/** A tool family as shown in the discovery overview. */
+interface FamilyOverviewRow {
+  key: string;
+  title: string;
+  count: number;
+}
+
+/** Precomputed catalogue derived once from {@link toolCategories}. */
+interface ToolCatalog {
+  rows: ToolCatalogRow[];
+  families: FamilyOverviewRow[];
+  familyByToolName: Map<string, string>;
+}
+
+/** Condenses a tool description to a single sentence for the discovery listing. */
+function toSummary(description: string): string {
+  const firstLine = description.split('\n', 1)[0].trim();
+  const sentenceEnd = firstLine.indexOf('. ');
+  const sentence = sentenceEnd === -1 ? firstLine : firstLine.slice(0, sentenceEnd + 1);
+  return sentence.length > 160 ? `${sentence.slice(0, 157)}...` : sentence;
+}
+
+/** Builds the discovery catalogue (tool rows, family overview, name→family index). */
+function buildCatalog(): ToolCatalog {
+  const rows: ToolCatalogRow[] = [];
+  const families: FamilyOverviewRow[] = [];
+  const familyByToolName = new Map<string, string>();
+
+  for (const category of toolCategories) {
+    families.push({ key: category.key, title: category.title, count: category.entries.length });
+    for (const entry of category.entries) {
+      const { name, description } = entry.definition;
+      rows.push({ name, family: category.key, summary: toSummary(description) });
+      familyByToolName.set(name, category.key);
+    }
+  }
+
+  return { rows, families, familyByToolName };
+}
+
+const CATALOG = buildCatalog();
+
+/**
+ * Resolves the tool names belonging to the given families, preserving the caller's
+ * ability to filter registry entries for static mode. Unknown family keys
+ * contribute nothing (they are rejected earlier by env validation).
+ */
+export function toolNamesInFamilies(families: Iterable<string>): Set<string> {
+  const wanted = new Set(families);
+  const names = new Set<string>();
+  for (const [name, family] of CATALOG.familyByToolName) {
+    if (wanted.has(family)) {
+      names.add(name);
+    }
+  }
+  return names;
+}
+
+/** Result of {@link ToolGatingController.enable} / {@link ToolGatingController.disable}. */
+interface MutationResult {
+  enabled?: string[];
+  disabled?: string[];
+  unknown: string[];
+  activeCount: number;
+}
+
+/**
+ * Drives the discovery meta-tools against the live set of registered tool handles.
+ * Backed by the per-connection `RegisteredTool` map, so enabling/disabling is
+ * naturally isolated to one client session.
+ */
+export interface ToolGatingController {
+  list(args: { family?: string; query?: string; cursor?: string; limit?: number }): unknown;
+  enable(names: string[]): MutationResult;
+  disable(names: string[]): MutationResult;
+}
+
+/** Parses an opaque list cursor (a stringified offset) back into a non-negative offset. */
+function parseCursor(cursor: string | undefined): number {
+  if (!cursor) {
+    return 0;
+  }
+  const offset = Number.parseInt(cursor, 10);
+  return Number.isInteger(offset) && offset > 0 ? offset : 0;
+}
+
+/**
+ * Creates the controller backing the discovery meta-tools.
+ *
+ * @param handles - Map of eBay tool name → its registered handle. Only these tools
+ *   are gateable; the meta-tools themselves are intentionally absent so they can
+ *   never be disabled and are excluded from `activeCount`.
+ */
+export function createToolGatingController(
+  handles: Map<string, RegisteredTool>
+): ToolGatingController {
+  const activeCount = (): number => [...handles.values()].filter((handle) => handle.enabled).length;
+
+  const mutate = (names: string[], enable: boolean): MutationResult => {
+    const changed: string[] = [];
+    const unknown: string[] = [];
+
+    for (const name of names) {
+      const handle = handles.get(name);
+      if (!handle) {
+        unknown.push(name);
+        continue;
+      }
+      if (handle.enabled !== enable) {
+        if (enable) {
+          handle.enable();
+        } else {
+          handle.disable();
+        }
+      }
+      changed.push(name);
+    }
+
+    return enable
+      ? { enabled: changed, unknown, activeCount: activeCount() }
+      : { disabled: changed, unknown, activeCount: activeCount() };
+  };
+
+  return {
+    list({ family, query, cursor, limit }) {
+      if (!family && !query) {
+        return {
+          families: CATALOG.families.map((row) => ({
+            ...row,
+            enabledCount: [...handles.entries()].filter(
+              ([name, handle]) => CATALOG.familyByToolName.get(name) === row.key && handle.enabled
+            ).length,
+          })),
+          hint: 'Call list_ebay_tools with { family } or { query } to list tools, then enable_ebay_tools.',
+        };
+      }
+
+      if (family && !CATALOG.families.some((row) => row.key === family)) {
+        return {
+          error: `Unknown tool family "${family}".`,
+          validFamilies: TOOL_FAMILY_KEYS,
+        };
+      }
+
+      const needle = query?.toLowerCase();
+      const matches = CATALOG.rows.filter((row) => {
+        if (family && row.family !== family) {
+          return false;
+        }
+        if (needle) {
+          return (
+            row.name.toLowerCase().includes(needle) ||
+            row.summary.toLowerCase().includes(needle) ||
+            row.family.includes(needle)
+          );
+        }
+        return true;
+      });
+
+      const offset = parseCursor(cursor);
+      const size = Math.min(limit ?? DEFAULT_LIST_LIMIT, MAX_LIST_LIMIT);
+      const page = matches.slice(offset, offset + size);
+      const nextOffset = offset + size;
+
+      return {
+        tools: page.map((row) => ({ ...row, enabled: handles.get(row.name)?.enabled ?? false })),
+        total: matches.length,
+        nextCursor: nextOffset < matches.length ? String(nextOffset) : undefined,
+      };
+    },
+
+    enable: (names) => mutate(names, true),
+    disable: (names) => mutate(names, false),
+  };
+}
+
+/** Wraps controller output as a standard text tool result. */
+function toToolResult(data: unknown): CallToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+}
+
+/**
+ * Registers the three discovery meta-tools on the server. Called only in dynamic
+ * mode, after the eBay tools are registered and disabled, so the controller sees
+ * every gateable handle.
+ */
+export function registerMetaTools(server: McpServer, controller: ToolGatingController): void {
+  server.registerTool(
+    'list_ebay_tools',
+    {
+      description:
+        "Discover eBay tools without loading them into context. Call with no arguments to list the tool families; pass `family` to list a family's tools, or `query` to keyword-search across all tools. Returns lightweight rows (name, family, summary) — enable a tool with enable_ebay_tools to get its full schema and call it.",
+      inputSchema: {
+        family: z
+          .string()
+          .optional()
+          .describe('Restrict results to one family key (e.g. "inventory").'),
+        query: z
+          .string()
+          .optional()
+          .describe('Case-insensitive keyword matched against tool name, summary, and family.'),
+        cursor: z.string().optional().describe('Pagination cursor from a prior call.'),
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .max(MAX_LIST_LIMIT)
+          .optional()
+          .describe(`Max rows per page (default ${DEFAULT_LIST_LIMIT}, max ${MAX_LIST_LIMIT}).`),
+      },
+    },
+    (args) => toToolResult(controller.list(args))
+  );
+
+  server.registerTool(
+    'enable_ebay_tools',
+    {
+      description:
+        'Load specific eBay tools into context so they can be called. Pass the exact tool names from list_ebay_tools. Returns the names enabled, any unknown names, and the active tool count.',
+      inputSchema: {
+        names: z
+          .array(z.string())
+          .min(1)
+          .describe('Exact tool names to enable, as returned by list_ebay_tools.'),
+      },
+    },
+    ({ names }) => toToolResult(controller.enable(names))
+  );
+
+  server.registerTool(
+    'disable_ebay_tools',
+    {
+      description:
+        'Unload eBay tools previously enabled, reclaiming their context. Pass the exact tool names. Returns the names disabled, any unknown names, and the active tool count.',
+      inputSchema: {
+        names: z.array(z.string()).min(1).describe('Exact tool names to disable.'),
+      },
+    },
+    ({ names }) => toToolResult(controller.disable(names))
+  );
+}

--- a/tests/unit/config/tool-families.test.ts
+++ b/tests/unit/config/tool-families.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getToolGatingConfigError,
+  resolveToolGatingMode,
+  TOOL_FAMILY_KEYS,
+} from '@/config/tool-families.js';
+import { toolCategories } from '@/tools/categories/index.js';
+
+describe('tool-families', () => {
+  describe('TOOL_FAMILY_KEYS', () => {
+    it('stays in lock-step with the registry categories (DRY guard)', () => {
+      expect([...TOOL_FAMILY_KEYS]).toEqual(toolCategories.map((category) => category.key));
+    });
+  });
+
+  describe('resolveToolGatingMode', () => {
+    it('defaults to "all" when unset', () => {
+      expect(resolveToolGatingMode({})).toEqual({ kind: 'all' });
+    });
+
+    it('treats "all" (any case) as all', () => {
+      expect(resolveToolGatingMode({ EBAY_MCP_TOOLS: 'ALL' })).toEqual({ kind: 'all' });
+    });
+
+    it('parses "dynamic"', () => {
+      expect(resolveToolGatingMode({ EBAY_MCP_TOOLS: 'dynamic' })).toEqual({ kind: 'dynamic' });
+    });
+
+    it('parses a comma list into trimmed, lowercased families', () => {
+      expect(resolveToolGatingMode({ EBAY_MCP_TOOLS: ' Inventory , fulfillment ' })).toEqual({
+        kind: 'static',
+        families: ['inventory', 'fulfillment'],
+      });
+    });
+  });
+
+  describe('getToolGatingConfigError', () => {
+    it('accepts unset, all, and dynamic', () => {
+      expect(getToolGatingConfigError({})).toBeUndefined();
+      expect(getToolGatingConfigError({ EBAY_MCP_TOOLS: 'all' })).toBeUndefined();
+      expect(getToolGatingConfigError({ EBAY_MCP_TOOLS: 'dynamic' })).toBeUndefined();
+    });
+
+    it('accepts a valid family list', () => {
+      expect(getToolGatingConfigError({ EBAY_MCP_TOOLS: 'inventory,fulfillment' })).toBeUndefined();
+    });
+
+    it('rejects an unknown family and lists the valid ones', () => {
+      const error = getToolGatingConfigError({ EBAY_MCP_TOOLS: 'inventroy,fulfillment' });
+      expect(error).toContain('inventroy');
+      expect(error).toContain('Valid families');
+      expect(error).toContain('inventory');
+    });
+
+    it('rejects a value that resolves to no families', () => {
+      expect(getToolGatingConfigError({ EBAY_MCP_TOOLS: ' , , ' })).toContain('no tool families');
+    });
+  });
+});

--- a/tests/unit/mcp/runtime-gating.test.ts
+++ b/tests/unit/mcp/runtime-gating.test.ts
@@ -63,20 +63,20 @@ const fakeApi = { initialize: vi.fn() } as never;
 const serverConfig = { name: 'test-mcp', version: '0.0.0' };
 const inventoryCount = toolCategories.find((category) => category.key === 'inventory')!.entries
   .length;
+const META_TOOL_NAMES = ['list_ebay_tools', 'enable_ebay_tools', 'disable_ebay_tools'];
 
 describe('createEbayMcpRuntime — tool gating', () => {
-  const originalEnv = process.env;
-
   beforeEach(() => {
-    process.env = { ...originalEnv };
-    delete process.env.EBAY_MCP_TOOLS;
+    // Stub only the gating key (not the whole process.env object) so dotenv-injected
+    // config from other modules survives across tests in the same worker.
+    vi.stubEnv('EBAY_MCP_TOOLS', undefined);
     vi.clearAllMocks();
     mcpMock.state.handles = [];
     mcpMock.state.constructorArgs = [];
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    vi.unstubAllEnvs();
   });
 
   it('registers the full catalogue and no meta-tools by default', async () => {
@@ -89,21 +89,21 @@ describe('createEbayMcpRuntime — tool gating', () => {
   });
 
   it('dynamic mode advertises only the 3 discovery tools and disables the rest', async () => {
-    process.env.EBAY_MCP_TOOLS = 'dynamic';
+    vi.stubEnv('EBAY_MCP_TOOLS', 'dynamic');
     const { createEbayMcpRuntime } = await import('@/mcp/runtime.js');
     createEbayMcpRuntime({ api: fakeApi, serverConfig });
 
     const total = getToolDefinitions().length;
-    expect(mcpMock.registerTool).toHaveBeenCalledTimes(total + 3);
+    expect(mcpMock.registerTool).toHaveBeenCalledTimes(total + META_TOOL_NAMES.length);
 
-    const ebayHandles = mcpMock.state.handles.slice(0, total);
-    const metaHandles = mcpMock.state.handles.slice(total);
+    // Classify by name, not registration order, so a registration-order refactor
+    // that preserves behavior does not break this test.
+    const metaNames = new Set(META_TOOL_NAMES);
+    const ebayHandles = mcpMock.state.handles.filter((handle) => !metaNames.has(handle.name));
+    const metaHandles = mcpMock.state.handles.filter((handle) => metaNames.has(handle.name));
+    expect(ebayHandles).toHaveLength(total);
     expect(ebayHandles.every((handle) => !handle.enabled)).toBe(true);
-    expect(metaHandles.map((handle) => handle.name)).toEqual([
-      'list_ebay_tools',
-      'enable_ebay_tools',
-      'disable_ebay_tools',
-    ]);
+    expect(metaHandles.map((handle) => handle.name).sort()).toEqual([...META_TOOL_NAMES].sort());
     expect(metaHandles.every((handle) => handle.enabled)).toBe(true);
 
     const [, options] = mcpMock.state.constructorArgs[0] as [unknown, { instructions?: string }];
@@ -111,7 +111,7 @@ describe('createEbayMcpRuntime — tool gating', () => {
   });
 
   it('static mode registers only the named families, frozen', async () => {
-    process.env.EBAY_MCP_TOOLS = 'inventory';
+    vi.stubEnv('EBAY_MCP_TOOLS', 'inventory');
     const { createEbayMcpRuntime } = await import('@/mcp/runtime.js');
     createEbayMcpRuntime({ api: fakeApi, serverConfig });
 

--- a/tests/unit/mcp/runtime-gating.test.ts
+++ b/tests/unit/mcp/runtime-gating.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getToolDefinitions } from '@/tools/index.js';
+import { toolCategories } from '@/tools/categories/index.js';
+
+/**
+ * Exercises the EBAY_MCP_TOOLS gating in createEbayMcpRuntime by mocking McpServer
+ * and capturing every registered tool handle, so we can assert which tools are
+ * registered and whether dynamic mode disables them at boot.
+ */
+const mcpMock = vi.hoisted(() => {
+  interface Handle {
+    name: string;
+    enabled: boolean;
+    enable(): void;
+    disable(): void;
+    update: ReturnType<typeof vi.fn>;
+  }
+  const state: { handles: Handle[]; constructorArgs: unknown[][] } = {
+    handles: [],
+    constructorArgs: [],
+  };
+  return {
+    state,
+    registerTool: vi.fn((name: string) => {
+      const handle: Handle = {
+        name,
+        enabled: true,
+        enable() {
+          handle.enabled = true;
+        },
+        disable() {
+          handle.enabled = false;
+        },
+        update: vi.fn(),
+      };
+      state.handles.push(handle);
+      return handle;
+    }),
+    registerResource: vi.fn(),
+    connect: vi.fn(),
+    close: vi.fn(),
+    getClientCapabilities: vi.fn(() => ({})),
+  };
+});
+
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: vi.fn(function (serverInfo: unknown, options: unknown) {
+    mcpMock.state.constructorArgs.push([serverInfo, options]);
+    return {
+      registerTool: mcpMock.registerTool,
+      registerResource: mcpMock.registerResource,
+      connect: mcpMock.connect,
+      close: mcpMock.close,
+      server: {
+        oninitialized: undefined,
+        getClientCapabilities: mcpMock.getClientCapabilities,
+      },
+    };
+  }),
+}));
+
+const fakeApi = { initialize: vi.fn() } as never;
+const serverConfig = { name: 'test-mcp', version: '0.0.0' };
+const inventoryCount = toolCategories.find((category) => category.key === 'inventory')!.entries
+  .length;
+
+describe('createEbayMcpRuntime — tool gating', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.EBAY_MCP_TOOLS;
+    vi.clearAllMocks();
+    mcpMock.state.handles = [];
+    mcpMock.state.constructorArgs = [];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('registers the full catalogue and no meta-tools by default', async () => {
+    const { createEbayMcpRuntime } = await import('@/mcp/runtime.js');
+    createEbayMcpRuntime({ api: fakeApi, serverConfig });
+
+    expect(mcpMock.registerTool).toHaveBeenCalledTimes(getToolDefinitions().length);
+    expect(mcpMock.state.handles.every((handle) => handle.enabled)).toBe(true);
+    expect(mcpMock.state.constructorArgs[0]).toEqual([serverConfig, undefined]);
+  });
+
+  it('dynamic mode advertises only the 3 discovery tools and disables the rest', async () => {
+    process.env.EBAY_MCP_TOOLS = 'dynamic';
+    const { createEbayMcpRuntime } = await import('@/mcp/runtime.js');
+    createEbayMcpRuntime({ api: fakeApi, serverConfig });
+
+    const total = getToolDefinitions().length;
+    expect(mcpMock.registerTool).toHaveBeenCalledTimes(total + 3);
+
+    const ebayHandles = mcpMock.state.handles.slice(0, total);
+    const metaHandles = mcpMock.state.handles.slice(total);
+    expect(ebayHandles.every((handle) => !handle.enabled)).toBe(true);
+    expect(metaHandles.map((handle) => handle.name)).toEqual([
+      'list_ebay_tools',
+      'enable_ebay_tools',
+      'disable_ebay_tools',
+    ]);
+    expect(metaHandles.every((handle) => handle.enabled)).toBe(true);
+
+    const [, options] = mcpMock.state.constructorArgs[0] as [unknown, { instructions?: string }];
+    expect(options.instructions).toContain('list_ebay_tools');
+  });
+
+  it('static mode registers only the named families, frozen', async () => {
+    process.env.EBAY_MCP_TOOLS = 'inventory';
+    const { createEbayMcpRuntime } = await import('@/mcp/runtime.js');
+    createEbayMcpRuntime({ api: fakeApi, serverConfig });
+
+    expect(mcpMock.registerTool).toHaveBeenCalledTimes(inventoryCount);
+    expect(mcpMock.state.handles.every((handle) => handle.enabled)).toBe(true);
+    expect(mcpMock.state.constructorArgs[0]).toEqual([serverConfig, undefined]);
+  });
+});

--- a/tests/unit/mcp/tool-gating.test.ts
+++ b/tests/unit/mcp/tool-gating.test.ts
@@ -96,7 +96,7 @@ describe('ToolGatingController', () => {
         nextCursor?: string;
       };
       expect(first.tools).toHaveLength(2);
-      expect(first.nextCursor).toBe('2');
+      expect(first.nextCursor).toBeDefined();
 
       const second = controller.list({
         family: 'inventory',

--- a/tests/unit/mcp/tool-gating.test.ts
+++ b/tests/unit/mcp/tool-gating.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { RegisteredTool } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  createToolGatingController,
+  registerMetaTools,
+  toolNamesInFamilies,
+} from '@/mcp/tool-gating.js';
+import { toolCategories } from '@/tools/categories/index.js';
+
+/** Minimal RegisteredTool stand-in exposing just the enabled flag the controller toggles. */
+function fakeHandle(enabled = false): RegisteredTool {
+  const handle = {
+    enabled,
+    enable() {
+      handle.enabled = true;
+    },
+    disable() {
+      handle.enabled = false;
+    },
+    update: vi.fn(),
+    remove: vi.fn(),
+  };
+  return handle as unknown as RegisteredTool;
+}
+
+/** Builds a handle map for every registered tool, as dynamic mode does (all disabled). */
+function buildHandles(): Map<string, RegisteredTool> {
+  const handles = new Map<string, RegisteredTool>();
+  for (const category of toolCategories) {
+    for (const entry of category.entries) {
+      handles.set(entry.definition.name, fakeHandle(false));
+    }
+  }
+  return handles;
+}
+
+const inventory = toolCategories.find((category) => category.key === 'inventory')!;
+const sampleTool = inventory.entries[0].definition.name;
+
+describe('toolNamesInFamilies', () => {
+  it('returns exactly the tools of the named families', () => {
+    const names = toolNamesInFamilies(['inventory']);
+    expect(names.size).toBe(inventory.entries.length);
+    expect(names.has(sampleTool)).toBe(true);
+  });
+
+  it('ignores unknown families', () => {
+    expect(toolNamesInFamilies(['nope']).size).toBe(0);
+  });
+});
+
+describe('ToolGatingController', () => {
+  describe('list', () => {
+    it('returns the family overview with no arguments', () => {
+      const controller = createToolGatingController(buildHandles());
+      const result = controller.list({}) as {
+        families: { key: string; count: number }[];
+      };
+      expect(result.families).toHaveLength(toolCategories.length);
+      const inventoryRow = result.families.find((row) => row.key === 'inventory');
+      expect(inventoryRow?.count).toBe(inventory.entries.length);
+    });
+
+    it('lists the tools of a family', () => {
+      const controller = createToolGatingController(buildHandles());
+      const result = controller.list({ family: 'inventory' }) as {
+        tools: { name: string; family: string }[];
+        total: number;
+      };
+      expect(result.total).toBe(inventory.entries.length);
+      expect(result.tools.every((tool) => tool.family === 'inventory')).toBe(true);
+    });
+
+    it('rejects an unknown family with the valid list', () => {
+      const controller = createToolGatingController(buildHandles());
+      const result = controller.list({ family: 'nope' }) as {
+        error: string;
+        validFamilies: readonly string[];
+      };
+      expect(result.error).toContain('nope');
+      expect(result.validFamilies).toContain('inventory');
+    });
+
+    it('keyword-searches across all tools by name', () => {
+      const controller = createToolGatingController(buildHandles());
+      const result = controller.list({ query: sampleTool.toLowerCase() }) as {
+        tools: { name: string }[];
+      };
+      expect(result.tools.some((tool) => tool.name === sampleTool)).toBe(true);
+    });
+
+    it('paginates with an opaque cursor', () => {
+      const controller = createToolGatingController(buildHandles());
+      const first = controller.list({ family: 'inventory', limit: 2 }) as {
+        tools: { name: string }[];
+        nextCursor?: string;
+      };
+      expect(first.tools).toHaveLength(2);
+      expect(first.nextCursor).toBe('2');
+
+      const second = controller.list({
+        family: 'inventory',
+        limit: 2,
+        cursor: first.nextCursor,
+      }) as {
+        tools: { name: string }[];
+      };
+      expect(second.tools[0].name).not.toBe(first.tools[0].name);
+    });
+  });
+
+  describe('enable / disable', () => {
+    it('enables a known tool and reports the active count', () => {
+      const handles = buildHandles();
+      const controller = createToolGatingController(handles);
+      const result = controller.enable([sampleTool]);
+      expect(result.enabled).toEqual([sampleTool]);
+      expect(result.unknown).toEqual([]);
+      expect(result.activeCount).toBe(1);
+      expect(handles.get(sampleTool)?.enabled).toBe(true);
+    });
+
+    it('soft-fails unknown names instead of throwing', () => {
+      const controller = createToolGatingController(buildHandles());
+      const result = controller.enable([sampleTool, 'made-up-tool']);
+      expect(result.enabled).toEqual([sampleTool]);
+      expect(result.unknown).toEqual(['made-up-tool']);
+    });
+
+    it('disables a previously enabled tool', () => {
+      const handles = buildHandles();
+      const controller = createToolGatingController(handles);
+      controller.enable([sampleTool]);
+      const result = controller.disable([sampleTool]);
+      expect(result.disabled).toEqual([sampleTool]);
+      expect(result.activeCount).toBe(0);
+      expect(handles.get(sampleTool)?.enabled).toBe(false);
+    });
+  });
+});
+
+describe('registerMetaTools', () => {
+  it('registers exactly the three discovery tools', () => {
+    const registerTool = vi.fn<(name: string, config: unknown, handler: unknown) => void>();
+    const server = { registerTool } as never;
+    registerMetaTools(server, createToolGatingController(buildHandles()));
+
+    const names = registerTool.mock.calls.map((call) => call[0]);
+    expect(names).toEqual(['list_ebay_tools', 'enable_ebay_tools', 'disable_ebay_tools']);
+  });
+
+  it('wires each meta-tool handler to the controller', () => {
+    const registerTool = vi.fn<(name: string, config: unknown, handler: unknown) => void>();
+    const server = { registerTool } as never;
+    const handles = buildHandles();
+    registerMetaTools(server, createToolGatingController(handles));
+
+    const enableCall = registerTool.mock.calls.find((call) => call[0] === 'enable_ebay_tools')!;
+    const handler = enableCall[2] as (args: { names: string[] }) => { content: { text: string }[] };
+    const result = handler({ names: [sampleTool] });
+    expect(handles.get(sampleTool)?.enabled).toBe(true);
+    expect(result.content[0].text).toContain(sampleTool);
+  });
+});


### PR DESCRIPTION
## **User description**
## What & why

Before this, the server advertised **all ~187 tools in a single `tools/list` on every connect**, dumping the full catalogue (descriptions + Zod schemas) into every agent's context window. There was no way to reduce that footprint. This adds an **opt-in** `EBAY_MCP_TOOLS` env var to cap what's advertised.

## Modes

| Value | Behavior | Hosts |
| --- | --- | --- |
| `all` / unset | Every tool advertised — **original behavior, untouched** | every host |
| `dynamic` | Boots advertising only 3 discovery meta-tools; agent enables tools on demand → they appear natively via the SDK's auto `tools/listChanged` | listChanged-capable (e.g. Claude) |
| `inventory,fulfillment,…` | Registers only the named families, frozen, no meta-tools | every host incl. ChatGPT/Cursor |

The 3 dynamic-mode discovery tools: `list_ebay_tools` (paginated family/keyword search), `enable_ebay_tools`, `disable_ebay_tools`.

## Design notes

- **Opt-in, zero breakage:** default/unset === today's behavior.
- **Advertise-on-demand per-tool enable** (keeps native schemas + Zod validation) rather than a generic dispatcher.
- **Circular-import constraint:** pure parse/validate lives in `src/config/tool-families.ts` — deliberately free of tool-tree imports because `config/environment.ts` validates the var and is itself imported by `tools/categories/token-management.ts` (would cycle). Catalogue + controller + meta-tools live in `src/mcp/tool-gating.ts`; `src/mcp/runtime.ts` applies the mode.
- Family keys mirror `toolCategories` (enforced by a DRY guard test). Unknown families **fail loud at startup**.
- Boot-time `.disable()` is silent (SDK guards `sendToolListChanged` on `isConnected()`, disables happen pre-connect). Per-connection isolation holds on both transports.
- Mirrors the existing `EBAY_MCP_UI` opt-in env-flag pattern.

## Tests & validation

- Adds **24 tests** (parse/validate + DRY guard, controller list/enable/disable/pagination/unknown, runtime wiring for all three modes).
- `npm run check` ✅ (0 errors) · `npm test` ✅ **1120 passed** · `npm run build` ✅

## Docs

`README.md`, `docs/auth/CONFIGURATION.md`, and `AGENTS.md` all document the new var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Control which eBay tools are exposed at startup**

### What Changed
- Added an `EBAY_MCP_TOOLS` setting to choose between exposing every tool, using a discovery-only mode, or loading only specific tool families
- In discovery mode, the server shows just three tools first: one to browse the catalog, one to enable tools, and one to disable them again
- Added startup validation so unknown family names or an empty list fail fast with a clear error
- Updated the server and docs to explain which hosts support each mode and how to name families correctly

### Impact
`✅ Smaller agent context`
`✅ Faster tool discovery in long chats`
`✅ Fewer startup misconfigurations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable tool exposure at startup, letting the server advertise all tools, discovery-only tools, or a selected set of tool families.
  * Introduced on-demand tool discovery and enable/disable actions for supported hosts.
  * Documented the full list of supported tool families and startup validation behavior.

* **Bug Fixes**
  * Added startup validation to fail fast when an unknown or empty tool-family selection is provided.
  * Kept tool availability aligned with the configured family list during runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `EBAY_MCP_TOOLS` to control which tools are advertised, reducing context size and enabling on-demand discovery where supported. Default behavior is unchanged.

- **New Features**
  - Env `EBAY_MCP_TOOLS`: `all` (default), `dynamic`, or a comma-separated family list.
  - Dynamic mode shows only `list_ebay_tools`, `enable_ebay_tools`, `disable_ebay_tools`; tools are enabled on demand via `tools/listChanged` (e.g. Claude).
  - Static mode registers only the named families; no meta-tools; works on all hosts. Include `connector` for ChatGPT connectors if needed.
  - Startup validation fails fast on unknown or empty family lists and prints valid options.
  - Docs updated and 24 tests added.

- **Refactors**
  - Typed the `static` mode `families` as `string[]` to allow lenient parsing; validation catches unknowns later.
  - Tests hardened: stub only `EBAY_MCP_TOOLS` via `vi.stubEnv`, classify tool handles by name (not order), and assert pagination cursor presence/advancement.

<sup>Written for commit f120fcc052a5cefbf1776d46f8841cf848d5fa8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YosefHayim/ebay-mcp/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

