### PR TITLE
fix(trading): derive X-EBAY-API-SITEID from EBAY_MARKETPLACE_ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ EBAY_CLIENT_SECRET=your_client_secret
 EBAY_ENVIRONMENT=sandbox            # or "production"
 EBAY_REDIRECT_URI=your_runame
 EBAY_MARKETPLACE_ID=EBAY_US         # default marketplace (overridable per tool)
+# EBAY_SITE_ID=0                    # Trading API site override; defaults from EBAY_MARKETPLACE_ID
 EBAY_CONTENT_LANGUAGE=en-US         # default request content language
 EBAY_USER_REFRESH_TOKEN=your_token  # for higher rate limits
 EBAY_MCP_UI=on                      # interactive MCP Apps views (beta); "off" forces plain JSON

--- a/docs/auth/CONFIGURATION.md
+++ b/docs/auth/CONFIGURATION.md
@@ -77,7 +77,15 @@ These credentials are obtained from the [eBay Developer Portal](https://develope
 - **Example:** `EBAY_US`, `EBAY_DE`, `EBAY_FR`
 - **Required:** No (optional default)
 - **Default:** `EBAY_US`
-- **Behavior:** Sent on all requests; defaults to `EBAY_US` if unset. Many tools accept a `marketplaceId` parameter that overrides this default.
+- **Behavior:** Sent on all requests; defaults to `EBAY_US` if unset. Many tools accept a `marketplaceId` parameter that overrides this default. REST calls send it as `X-EBAY-C-MARKETPLACE-ID`; Trading API calls (listing create/revise, order tools) send the matching numeric site as `X-EBAY-API-SITEID` — see `EBAY_SITE_ID`.
+
+#### `EBAY_SITE_ID`
+
+- **Description:** Trading API site ID override (`X-EBAY-API-SITEID`)
+- **Example:** `0` (US), `77` (Germany), `3` (UK)
+- **Required:** No
+- **Default:** derived from `EBAY_MARKETPLACE_ID` (e.g. `EBAY_DE` → `77`), falling back to `0`
+- **Behavior:** Only needed for sites the marketplace mapping does not cover, or when REST and Trading must target different sites. The site determines which currency a listing may use, so a mismatch fails with `Invalid auction currency`.
 
 #### `EBAY_CONTENT_LANGUAGE`
 

--- a/src/api/clientTrading.ts
+++ b/src/api/clientTrading.ts
@@ -3,7 +3,7 @@ import { XMLParser } from 'fast-xml-parser';
 import type { EbayApiClient } from '@/api/client.js';
 import { TradingApiFailure } from '@/api/clientTradingError.js';
 import { EbayApiError } from '@/api/shared/request.js';
-import { getBaseUrl } from '@/config/environment.js';
+import { getBaseUrl, getTradingSiteId } from '@/config/environment.js';
 import { getErrorMessage } from '@/utils/errors.js';
 import { httpRequestEffect } from '@/utils/http.js';
 import { apiLogger } from '@/utils/logger.js';
@@ -11,7 +11,6 @@ import { isRecord } from '@/utils/typeGuards.js';
 import { Effect } from 'effect';
 
 const COMPAT_LEVEL = '1451';
-const SITE_ID = '0';
 const TRADING_ENDPOINT_PATH = '/ws/api.dll';
 const TRADING_XMLNS = 'urn:ebay:apis:eBLBaseComponents';
 
@@ -50,7 +49,7 @@ interface TradingParseContext extends TradingFailureContext {
 const buildTradingPath = (baseUrl: string): string => `${baseUrl}${TRADING_ENDPOINT_PATH}`;
 
 const buildTradingHeaders = (callName: string): Record<string, string> => ({
-  'X-EBAY-API-SITEID': SITE_ID,
+  'X-EBAY-API-SITEID': getTradingSiteId(),
   'X-EBAY-API-COMPATIBILITY-LEVEL': COMPAT_LEVEL,
   'X-EBAY-API-CALL-NAME': callName,
   'Content-Type': 'text/xml',

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -312,6 +312,65 @@ export const getEbayConfig = (): EbayConfig => {
 };
 
 /**
+ * Trading API site IDs for each REST marketplace ID.
+ *
+ * The Trading API predates the REST marketplace IDs and identifies a site with
+ * a numeric `X-EBAY-API-SITEID` header instead. The mapping is fixed by eBay.
+ *
+ * @see https://developer.ebay.com/devzone/merchandising/docs/CallRef/Enums/GlobalIdList.html
+ */
+const TRADING_SITE_IDS: Readonly<Record<string, string>> = {
+  EBAY_AT: '16',
+  EBAY_AU: '15',
+  EBAY_BE: '23',
+  EBAY_CA: '2',
+  EBAY_CH: '193',
+  EBAY_DE: '77',
+  EBAY_ES: '186',
+  EBAY_FR: '71',
+  EBAY_GB: '3',
+  EBAY_HK: '201',
+  EBAY_IE: '205',
+  EBAY_IN: '203',
+  EBAY_IT: '101',
+  EBAY_MY: '207',
+  EBAY_NL: '146',
+  EBAY_PH: '211',
+  EBAY_PL: '212',
+  EBAY_SG: '216',
+  EBAY_US: '0',
+};
+
+const DEFAULT_TRADING_SITE_ID = '0';
+
+/**
+ * Get the Trading API site ID for the configured marketplace.
+ *
+ * Derived from `EBAY_MARKETPLACE_ID` so a single setting drives both REST and
+ * Trading traffic. `EBAY_SITE_ID` overrides it for sites this map does not
+ * cover, or when REST and Trading must target different sites.
+ *
+ * Listing on a non-US site with the wrong site ID fails at eBay: the currency
+ * belongs to the marketplace, so an EUR listing sent to site 0 is rejected
+ * with "Invalid auction currency".
+ *
+ * @returns Numeric Trading API site ID sent as `X-EBAY-API-SITEID`.
+ * @example
+ * ```ts
+ * // EBAY_MARKETPLACE_ID=EBAY_DE
+ * const siteId = getTradingSiteId(); // '77'
+ * ```
+ */
+export const getTradingSiteId = (): string => {
+  const override = (process.env.EBAY_SITE_ID ?? '').trim();
+  if (override !== '') {
+    return override;
+  }
+  const marketplaceId = (process.env.EBAY_MARKETPLACE_ID ?? '').trim() || 'EBAY_US';
+  return TRADING_SITE_IDS[marketplaceId] ?? DEFAULT_TRADING_SITE_ID;
+};
+
+/**
  * Get the eBay REST API base URL for the configured environment.
  *
  * @param environment eBay environment used when no override is configured.

--- a/tests/unit/config/environment.test.ts
+++ b/tests/unit/config/environment.test.ts
@@ -4,6 +4,7 @@ import {
   getBaseUrl,
   getIdentityBaseUrl,
   getProxyAuthConfig,
+  getTradingSiteId,
   validateEnvironmentConfig,
 } from '@/config/environment.js';
 import process from 'node:process';
@@ -336,6 +337,43 @@ describe('Environment Configuration', () => {
       const proxy = getProxyAuthConfig();
 
       expect(proxy.warnings.some((w) => w.includes('transmitted unencrypted'))).toBe(false);
+    });
+  });
+
+  describe('getTradingSiteId', () => {
+    it('maps the configured marketplace to its Trading API site ID', () => {
+      process.env.EBAY_MARKETPLACE_ID = 'EBAY_DE';
+      delete process.env.EBAY_SITE_ID;
+
+      expect(getTradingSiteId()).toBe('77');
+    });
+
+    it('defaults to the US site when no marketplace is configured', () => {
+      delete process.env.EBAY_MARKETPLACE_ID;
+      delete process.env.EBAY_SITE_ID;
+
+      expect(getTradingSiteId()).toBe('0');
+    });
+
+    it('falls back to the US site for an unknown marketplace', () => {
+      process.env.EBAY_MARKETPLACE_ID = 'EBAY_ATLANTIS';
+      delete process.env.EBAY_SITE_ID;
+
+      expect(getTradingSiteId()).toBe('0');
+    });
+
+    it('lets EBAY_SITE_ID override the marketplace mapping', () => {
+      process.env.EBAY_MARKETPLACE_ID = 'EBAY_DE';
+      process.env.EBAY_SITE_ID = '3';
+
+      expect(getTradingSiteId()).toBe('3');
+    });
+
+    it('ignores a blank EBAY_SITE_ID override', () => {
+      process.env.EBAY_MARKETPLACE_ID = 'EBAY_DE';
+      process.env.EBAY_SITE_ID = '   ';
+
+      expect(getTradingSiteId()).toBe('77');
     });
   });
 });


### PR DESCRIPTION
## **User description**
## Problem

`src/api/clientTrading.ts` hardcoded the Trading API site:

```ts
const SITE_ID = '0';   // eBay US
```

`EBAY_MARKETPLACE_ID` never reached the Trading API — it is read in `getEbayConfig()` and only becomes the `X-EBAY-C-MARKETPLACE-ID` header on **REST** calls. `clientTrading.ts` imports just `getBaseUrl` from the config module.

Reads still work (own-listing reads are not site-scoped), so the misconfiguration is invisible until the first write. Creating a listing on a non-US marketplace then fails at eBay:

```
eBay POST https://api.ebay.com/ws/api.dll failed: Invalid auction currency.
```

The currency is validated against the site, so an EUR listing sent to site `0` is rejected. In practice `ebay_create_listing` / `ebay_revise_listing` are unusable on every marketplace except the US, with no environment variable to work around it. Hit this on a live eBay.de seller account with `EBAY_MARKETPLACE_ID=EBAY_DE` set.

## Fix

Derive the site ID from `EBAY_MARKETPLACE_ID` using eBay's fixed mapping (`EBAY_DE` → `77`, `EBAY_GB` → `3`, …), so one setting drives REST and Trading traffic alike. `EBAY_SITE_ID` is added as an override for sites the map does not cover, or when REST and Trading must intentionally differ.

Unknown or unset marketplaces still resolve to `0`, so existing US setups behave exactly as before.

## Changes

- `src/config/environment.ts` — `TRADING_SITE_IDS` map + exported `getTradingSiteId()`
- `src/api/clientTrading.ts` — header uses `getTradingSiteId()` instead of the constant
- `tests/unit/config/environment.test.ts` — 5 tests: marketplace mapping, unset default, unknown-marketplace fallback, override, blank-override ignored
- `README.md` + `docs/auth/CONFIGURATION.md` — document `EBAY_SITE_ID` and the REST/Trading header split

## Verification

- `npx vitest run` → 1051 passed (59 files)
- `npx tsc --noEmit` → clean
- Verified against the live Trading API: same `AddFixedPriceItem` payload that returned `Invalid auction currency` on site `0` is accepted with `EBAY_MARKETPLACE_ID=EBAY_DE`.

Note: `biome check src/api/clientTrading.ts` panics with an internal error, but it does so on unmodified `main` too — pre-existing, unrelated to this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives Trading’s `X-EBAY-API-SITEID` from `EBAY_MARKETPLACE_ID` so listing writes work on non-US sites and no longer fail with “Invalid auction currency.” Adds `EBAY_SITE_ID` as an optional override; US behavior stays the default.

- **Bug Fixes**
  - Added `getTradingSiteId()` mapping and used it in `src/api/clientTrading.ts`.
  - Default and unknown marketplace → site `0` (US); blank override ignored.
  - New `EBAY_SITE_ID` env var to override the mapping when needed.
  - Tests cover mapping, defaults, unknown fallback, and override.
  - Docs updated to explain REST vs Trading headers and the new env var.

<sup>Written for commit 8ad9363012e5d1bec40569e201ad40294a5c7c00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YosefHayim/ebay-mcp/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Use the correct Trading API site for the chosen marketplace**

### What Changed
- Trading API requests now send the site ID that matches `EBAY_MARKETPLACE_ID` instead of always using the US site
- Non-US marketplaces can now create and revise listings with the right site and currency combination
- `EBAY_SITE_ID` can override the mapped site when a marketplace is not covered or REST and Trading need different sites
- Documentation and tests now cover the marketplace-to-site mapping and override behavior

### Impact
`✅ Fewer listing failures on non-US eBay accounts`
`✅ Clearer marketplace-to-site behavior`
`✅ Lower risk of "Invalid auction currency" errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trading API requests now automatically use the site associated with the configured marketplace.
  * Added support for overriding the Trading API site with `EBAY_SITE_ID`.

* **Bug Fixes**
  * Improved handling of marketplace and currency differences by selecting the appropriate Trading API site.

* **Documentation**
  * Expanded configuration guidance for `EBAY_SITE_ID`, including defaults, overrides, and API-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->