### PR TITLE
chore(release): v1.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.3] - 2026-08-07
+
+### Fixed
+
+- **Empty-body MCP results (#151)** — eBay 201/204 responses with no body no longer produce invalid MCP content (`JSON.stringify(undefined)`). Hosts receive a valid `{ status: "success" }` text block.
+- **Published `diagnose` / setup / skills (#153)** — npm scripts run built `node build/scripts/*.js` entrypoints; `ebay-mcp diagnose` works on global installs without `tsx` or `src/`.
+- **Refresh token persistence (#154)** — serialize concurrent `.env` credential writes, best-effort fsync, and fail OAuth exchange when eBay omits `refresh_token` so tools never claim a false save.
+- **Fulfillment policy shipping codes (#152)** — document marketplace-valid `shippingServiceCode` discovery and a known-good FLAT_RATE sketch (eBay dual-index errors are remote validation, not client array duplication).
+
 ## [1.14.2] - 2026-07-28
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ebay-mcp",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "Model Context Protocol (MCP) server that exposes 100% of eBay's Sell APIs (298 tools across 270 endpoints) to AI assistants like Claude, Cursor, and Cline, covering inventory, order fulfillment, marketing, analytics, and developer tools with OAuth authentication and refresh-token support.",
   "type": "module",
   "main": "build/index.js",


### PR DESCRIPTION
## Summary

Complete the **v1.14.3** release that the automated Release workflow started but could not finish: branch protection blocked `github-actions` from pushing the version bump commit to `main` (tag `v1.14.3` was already pushed).

- Bumps `package.json` to **1.14.3**
- Adds CHANGELOG notes for #151–#154

After merge: create GitHub Release for `v1.14.3` (if missing) and run **Publish Package** so npm receives the release.

## Test plan

- [x] Tag `v1.14.3` already exists with the fix commits + version bump tree
- [ ] CI Gate green on this PR
- [ ] Merge to main
- [ ] npm shows `ebay-mcp@1.14.3`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalize the v1.14.3 release by bumping `package.json` to 1.14.3 and adding CHANGELOG notes for fixes #151–#154; this unblocks the automated release that was halted by branch protection (tag `v1.14.3` already exists). After merge, publish the GitHub Release and run the Publish Package workflow to ship `ebay-mcp@1.14.3` to npm.

- **Bug Fixes**
  - Handle 201/204 empty-body MCP results; return `{ status: "success" }` text.
  - Make `diagnose`/setup/skills work from built scripts; `ebay-mcp diagnose` works globally.
  - Improve refresh token persistence; serialize writes, fsync, and fail when token is missing.
  - Document fulfillment policy `shippingServiceCode` discovery and a FLAT_RATE example.

<sup>Written for commit fc053adf18546d0b6e9419c029b420fc09e11100. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YosefHayim/ebay-mcp/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

