### PR TITLE
fix(account): prove fulfillment policy write tools

### DIFF
--- a/.changeset/fulfillment-policy-crud.md
+++ b/.changeset/fulfillment-policy-crud.md
@@ -1,0 +1,9 @@
+---
+"ebay-mcp": patch
+---
+
+Document and verify fulfillment-policy create and update tools across the registered MCP surface.
+
+Both tools now advertise the required account write scope consistently, the OAuth scope catalogue
+covers updates, and protocol-level integration tests lock their input schemas and eBay request
+contracts.

--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Common tasks, phrased as you'd ask your AI assistant:
 
 - **Set up OAuth** — *"Help me set up OAuth for my eBay account."* → generates an authorization URL via `ebay_get_oauth_url`, then configures the refresh token. Unlocks 10k–50k req/day.
 - **Manage inventory** — *"Show me all my active listings."* → `ebay_get_inventory_items` returns SKUs, quantities, and status.
+- **Manage fulfillment policies** — *"Create a shipping policy, then update its handling time."* → `ebay_create_fulfillment_policy` creates the reusable policy ID and `ebay_update_fulfillment_policy` replaces its settings.
 - **Process orders** — *"Get all unfulfilled orders from the last 7 days."* → `ebay_get_orders` with date and fulfillment-status filters.
 - **Create campaigns** — *"Create a promoted-listing campaign for electronics."* → `ebay_create_campaign` and related marketing tools.
 - **Bulk operations** — *"Apply a 10% discount to all 'Vintage Watches' items."* → `ebay_get_inventory_items` + `ebay_update_offer` across matches.

--- a/src/auth/scopeUtils.ts
+++ b/src/auth/scopeUtils.ts
@@ -176,6 +176,11 @@ export const getRequiredScopesForTool = (toolName: string): ScopeRequirement | n
       minimumScope: 'https://api.ebay.com/oauth/api_scope/sell.account',
       description: 'Requires write access to account settings',
     },
+    ebay_update_fulfillment_policy: {
+      requiredScopes: ['https://api.ebay.com/oauth/api_scope/sell.account'],
+      minimumScope: 'https://api.ebay.com/oauth/api_scope/sell.account',
+      description: 'Requires write access to account settings',
+    },
 
     // Marketing Tools
     ebay_get_campaigns: {

--- a/src/tools/categories/account.ts
+++ b/src/tools/categories/account.ts
@@ -165,7 +165,8 @@ export const accountEntries: ToolEntry[] = [
   }),
   defineTool({
     name: 'ebay_update_fulfillment_policy',
-    description: 'Update an existing fulfillment policy',
+    description:
+      'Update an existing fulfillment policy.\n\nRequired OAuth Scope: sell.account\nMinimum Scope: https://api.ebay.com/oauth/api_scope/sell.account',
     inputSchema: updateFulfillmentPolicyInputSchema.shape,
     outputSchema: zodToJsonSchema(createFulfillmentPolicyOutputSchema, {
       name: 'UpdateFulfillmentPolicyResponse',

--- a/tests/integration/tools/fulfillmentPolicyTools.test.ts
+++ b/tests/integration/tools/fulfillmentPolicyTools.test.ts
@@ -1,0 +1,119 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { EbaySellerApi } from '@/api/index.js';
+import { createEbayMcpRuntime } from '@/mcp/runtime.js';
+import type { EbayConfig } from '@/types/ebay.js';
+import { Effect } from 'effect';
+import nock from 'nock';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+const mockOAuthClient = {
+  hasUserTokens: vi.fn(),
+  getAccessToken: vi.fn(),
+  setUserTokens: vi.fn(),
+  initialize: vi.fn(),
+  getTokenInfo: vi.fn(),
+  isAuthenticated: vi.fn(),
+};
+
+vi.mock('../../../src/auth/oauth.js', () => ({
+  EbayOAuthClient: vi.fn(function (this: unknown) {
+    return mockOAuthClient;
+  }),
+}));
+
+const config: EbayConfig = {
+  clientId: 'test_client_id',
+  clientSecret: 'test_client_secret',
+  environment: 'sandbox',
+  redirectUri: 'https://localhost/callback',
+};
+
+const policy = {
+  name: 'Standard Shipping',
+  marketplaceId: 'EBAY_US',
+  handlingTime: { unit: 'DAY', value: 1 },
+};
+
+let client: Client;
+let runtime: ReturnType<typeof createEbayMcpRuntime>;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  vi.stubEnv('EBAY_MCP_TOOLS', 'account');
+  nock.cleanAll();
+  nock.disableNetConnect();
+
+  mockOAuthClient.hasUserTokens.mockReturnValue(true);
+  mockOAuthClient.getAccessToken.mockReturnValue(Effect.succeed('mock_access_token'));
+  mockOAuthClient.initialize.mockReturnValue(Effect.succeed(undefined));
+
+  const api = new EbaySellerApi(config);
+  await Effect.runPromise(api.initialize());
+  runtime = createEbayMcpRuntime({
+    api,
+    serverConfig: { name: 'fulfillment-policy-test', version: '0.0.0' },
+  });
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  client = new Client({ name: 'integration-client', version: '0.0.0' });
+  await runtime.server.connect(serverTransport);
+  await client.connect(clientTransport);
+});
+
+afterEach(async () => {
+  await client.close();
+  await runtime.server.close();
+  nock.cleanAll();
+  nock.enableNetConnect();
+  vi.unstubAllEnvs();
+});
+
+it('advertises fulfillment policy create and update through connected MCP', async () => {
+  const result = await client.listTools();
+  const tools = new Map(result.tools.map((tool) => [tool.name, tool]));
+
+  expect(tools.get('ebay_create_fulfillment_policy')?.inputSchema.required).toEqual(['policy']);
+  expect(tools.get('ebay_update_fulfillment_policy')?.inputSchema.required).toEqual([
+    'fulfillmentPolicyId',
+    'policy',
+  ]);
+});
+
+it('calls the create endpoint with the validated policy body', async () => {
+  const endpoint = nock('https://api.sandbox.ebay.com')
+    .post('/sell/account/v1/fulfillment_policy/', policy)
+    .reply(201, { fulfillmentPolicyId: 'FP123' });
+
+  const result = await client.callTool({
+    name: 'ebay_create_fulfillment_policy',
+    arguments: { policy },
+  });
+
+  expect(endpoint.isDone()).toBe(true);
+  expect(result.content).toEqual([
+    {
+      type: 'text',
+      text: JSON.stringify({ fulfillmentPolicyId: 'FP123' }, null, 2),
+    },
+  ]);
+});
+
+it('calls the update endpoint with the ID in the path and policy in the body', async () => {
+  const endpoint = nock('https://api.sandbox.ebay.com')
+    .put('/sell/account/v1/fulfillment_policy/FP123', policy)
+    .reply(200, { fulfillmentPolicyId: 'FP123' });
+
+  const result = await client.callTool({
+    name: 'ebay_update_fulfillment_policy',
+    arguments: { fulfillmentPolicyId: 'FP123', policy },
+  });
+
+  expect(endpoint.isDone()).toBe(true);
+  expect(result.content).toEqual([
+    {
+      type: 'text',
+      text: JSON.stringify({ fulfillmentPolicyId: 'FP123' }, null, 2),
+    },
+  ]);
+});

--- a/tests/unit/tools/fulfillmentPolicyTools.test.ts
+++ b/tests/unit/tools/fulfillmentPolicyTools.test.ts
@@ -1,0 +1,31 @@
+import { getRequiredScopesForTool } from '@/auth/scopeUtils.js';
+import { getToolDefinitions } from '@/tools/index.js';
+import { describe, expect, it } from 'vitest';
+
+const policyToolNames = [
+  'ebay_create_fulfillment_policy',
+  'ebay_update_fulfillment_policy',
+] as const;
+
+describe('fulfillment policy write tools', () => {
+  it('advertises create and update with their required input contracts', () => {
+    const definitions = new Map(
+      getToolDefinitions().map((definition) => [definition.name, definition]),
+    );
+
+    const createTool = definitions.get(policyToolNames[0]);
+    const updateTool = definitions.get(policyToolNames[1]);
+
+    expect(Object.keys(createTool?.inputSchema ?? {})).toEqual(['policy']);
+    expect(Object.keys(updateTool?.inputSchema ?? {})).toEqual(['fulfillmentPolicyId', 'policy']);
+    expect(createTool?.description).toContain('sell.account');
+    expect(updateTool?.description).toContain('sell.account');
+  });
+
+  it.each(policyToolNames)('%s requires the account write scope', (toolName) => {
+    expect(getRequiredScopesForTool(toolName)).toMatchObject({
+      requiredScopes: ['https://api.ebay.com/oauth/api_scope/sell.account'],
+      minimumScope: 'https://api.ebay.com/oauth/api_scope/sell.account',
+    });
+  });
+});


### PR DESCRIPTION
## **User description**
Fixes #162

## Summary
- Verify the existing fulfillment-policy create and update tools through a connected MCP client.
- Lock the create POST and update PUT path/body contracts with hermetic integration tests.
- Document the update tool account-write scope in both tool metadata and the OAuth scope catalogue.
- Advertise the workflow in the README and add a patch changeset.

## Context
The endpoint methods and tool definitions already existed on current main, so this PR closes the meaningful exposure, contract-proof, scope-documentation, and release gaps instead of duplicating them.

## Confidence
9/10

## Test plan
- `pnpm run check:ci` (pass; pre-existing warnings only)
- `pnpm run typecheck` (pass)
- `pnpm run typecheck:ui` (pass)
- `pnpm test` (62 files, 1085 tests passed)
- `pnpm run test:integration` (3 files, 36 tests passed)
- `pnpm run build` (pass)
- Connected MCP client `listTools` / `callTool` proof over `InMemoryTransport` (pass)

## QA
Manual/UI QA: N/A — MCP API surface; protocol-level headless QA is covered by the integration suite.


___

## **CodeAnt-AI Description**
Verify and document fulfillment policy creation and updates through MCP

### What Changed
- Fulfillment policy creation and updates are now documented as supported account-management workflows
- The update tool clearly identifies the required `sell.account` OAuth write scope
- The OAuth scope catalogue includes fulfillment policy updates
- Connected MCP tests verify both tools, their required inputs, and the exact eBay create and update requests

### Impact
`✅ Fulfillment policy writes available through documented MCP workflows`
`✅ Clearer OAuth requirements for policy updates`
`✅ Fewer fulfillment policy request-contract regressions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advertises and validates fulfillment-policy write tools over MCP and aligns OAuth scope requirements. Previously, `ebay_update_fulfillment_policy` lacked scope metadata and MCP contract proof; now both tools require `sell.account` and have locked input/path contracts.

- Adds `sell.account` scope mapping for `ebay_update_fulfillment_policy` in `getRequiredScopesForTool`; calls without this scope now fail preflight.
- Documents the required scope in tool descriptions and the OAuth scope catalogue; README adds a fulfillment-policy workflow.
- Adds protocol-level tests that prove POST/PUT contracts and MCP tool schemas; unit tests cover registry and scope.
- Adds a patch changeset.

**Rollout**
- Ensure the OAuth token includes `https://api.ebay.com/oauth/api_scope/sell.account` when calling `ebay_create_fulfillment_policy` or `ebay_update_fulfillment_policy`.

<sup>Written for commit 74d8037c6e1d7edb13a4fc7ed485fc942866ae47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YosefHayim/ebay-mcp/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for creating and updating eBay fulfillment policies.
  - Added the required account write-access authorization for fulfillment-policy updates.
  - Improved scope details shown for the update operation.

- **Documentation**
  - Added an example demonstrating how to create and then update a fulfillment policy.

- **Tests**
  - Added coverage validating fulfillment-policy inputs, authorization requirements, requests, and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->