### PR TITLE
fix(auth): preserve refreshed tokens on persistence failure

### DIFF
--- a/.changeset/fix-token-refresh-persistence.md
+++ b/.changeset/fix-token-refresh-persistence.md
@@ -1,0 +1,5 @@
+---
+"ebay-mcp": patch
+---
+
+Persist refreshed OAuth credentials to the same package-root `.env` file used at startup, and retain valid in-memory access tokens when only the persistence step fails.

--- a/src/auth/credentialSession.ts
+++ b/src/auth/credentialSession.ts
@@ -1,10 +1,9 @@
 import dotenv from 'dotenv';
 import stringify from 'dotenv-stringify';
 import { closeSync, existsSync, fsyncSync, openSync, readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { CREDENTIAL_ENV_PATH } from '@/config/credentialFile.js';
 import type { EbayConfig, EbayUserToken, StoredTokenData } from '@/types/ebay.js';
 import { Data, Effect } from 'effect';
-import process from 'node:process';
 
 /**
  * Default lifetime for stored eBay user access tokens when eBay omits an expiry.
@@ -80,7 +79,7 @@ const writeLockForEnvPath = (envPath: string): Effect.Semaphore => {
  * callers cannot interleave read-modify-write on the same `.env` path.
  */
 export class DotEnvCredentialStore implements CredentialStore {
-  constructor(private readonly getEnvPath: () => string = () => join(process.cwd(), '.env')) {}
+  constructor(private readonly getEnvPath: () => string = () => CREDENTIAL_ENV_PATH) {}
 
   /**
    * Merges credential updates into the project `.env` file.

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -2,10 +2,10 @@ import {
   createAppAccessTokenExpiry,
   createStoredUserTokens,
   createStoredUserTokensFromResponse,
+  CredentialStoreError,
   DotEnvCredentialStore,
   isTokenExpired,
   type CredentialStore,
-  type CredentialStoreError,
   type EbayUserTokenResponse,
 } from '@/auth/credentialSession.js';
 import { getBaseUrl, getDefaultScopes } from '@/config/environment.js';
@@ -70,6 +70,9 @@ const mapCredentialStoreError = (
     message: `${message}: ${cause.message}`,
     cause,
   });
+
+const isCredentialPersistenceError = (error: EbayOAuthError): boolean =>
+  error.cause instanceof CredentialStoreError;
 
 /**
  * Manages eBay OAuth 2.0 authentication
@@ -147,12 +150,19 @@ export class EbayOAuthClient {
 
         if (Either.isLeft(refreshed)) {
           const error = refreshed.left;
-          authLogger.error('Failed to refresh access token', {
-            error: getErrorMessage(error, String(error)),
-            hint: 'The configured EBAY_USER_REFRESH_TOKEN may be invalid or expired',
-          });
-          // Clear invalid tokens
-          this.userTokens = null;
+          if (isCredentialPersistenceError(error)) {
+            authLogger.error('Access token refreshed but could not be persisted', {
+              error: getErrorMessage(error, String(error)),
+              hint: 'The refreshed token remains available for this process, but the credential file must be writable to survive a restart',
+            });
+          } else {
+            authLogger.error('Failed to refresh access token', {
+              error: getErrorMessage(error, String(error)),
+              hint: 'The configured EBAY_USER_REFRESH_TOKEN may be invalid or expired',
+            });
+            // Clear tokens only when the refresh itself failed.
+            this.userTokens = null;
+          }
         }
       }
     });
@@ -222,10 +232,22 @@ export class EbayOAuthClient {
         const refreshed = yield* Effect.either(this.refreshUserToken());
 
         if (Either.isLeft(refreshed)) {
+          if (
+            isCredentialPersistenceError(refreshed.left) &&
+            this.userTokens &&
+            !this.isUserAccessTokenExpired(this.userTokens)
+          ) {
+            authLogger.error('User token refreshed but could not be persisted', {
+              error: getErrorMessage(refreshed.left, String(refreshed.left)),
+              hint: 'Using the valid refreshed token for this process only',
+            });
+            return this.userTokens.userAccessToken;
+          }
+
           authLogger.error('Failed to refresh user token, falling back to app access token', {
             error: getErrorMessage(refreshed.left, String(refreshed.left)),
           });
-          // Clear invalid tokens
+          // Clear tokens only when no valid refreshed access token remains.
           this.userTokens = null;
         } else if (this.userTokens) {
           return this.userTokens.userAccessToken;

--- a/src/config/credentialFile.ts
+++ b/src/config/credentialFile.ts
@@ -1,0 +1,19 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Resolve the credential `.env` file from an installed source or build module URL.
+ *
+ * @param moduleUrl - URL of a module in `src/config` or `build/config`.
+ * @returns Absolute path to the package-root credential file.
+ *
+ * @example
+ * ```ts
+ * resolveCredentialEnvPath(import.meta.url);
+ * ```
+ */
+export const resolveCredentialEnvPath = (moduleUrl: string | URL): string =>
+  join(dirname(fileURLToPath(moduleUrl)), '../../.env');
+
+/** Package-root credential file used for both runtime reads and token writes. */
+export const CREDENTIAL_ENV_PATH = resolveCredentialEnvPath(import.meta.url);

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -2,6 +2,7 @@ import { config } from 'dotenv';
 import { existsSync, readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { CREDENTIAL_ENV_PATH } from '@/config/credentialFile.js';
 import type { EbayConfig } from '@/types/ebay.js';
 import type { Implementation } from '@modelcontextprotocol/sdk/types.js';
 import { getToolGatingConfigError } from '@/config/toolFamilies.js';
@@ -17,7 +18,7 @@ const __dirname = dirname(__filename);
 // Load .env from the package root (two levels up from src/config/), not process.cwd().
 // MCP servers inherit cwd from the host (e.g. Claude Code's project dir), so
 // process.cwd() may point to an unrelated project with a different .env.
-config({ path: join(__dirname, '../../.env'), quiet: true });
+config({ path: CREDENTIAL_ENV_PATH, quiet: true });
 
 const writeConfigDiagnostic = (message: string): void => {
   process.stderr.write(`[eBay MCP] ${message}\n`);

--- a/tests/integration/authTokenPersistence.test.ts
+++ b/tests/integration/authTokenPersistence.test.ts
@@ -1,0 +1,73 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import dotenv from 'dotenv';
+import { Effect } from 'effect';
+import nock from 'nock';
+import { DotEnvCredentialStore } from '@/auth/credentialSession.js';
+import { EbayOAuthClient } from '@/auth/oauth.js';
+import type { EbayConfig } from '@/types/ebay.js';
+
+const config: EbayConfig = {
+  clientId: 'integration_client_id',
+  clientSecret: 'integration_client_secret',
+  environment: 'sandbox',
+  refreshToken: 'integration_refresh_token',
+};
+
+describe('OAuth token persistence', () => {
+  let tempDir: string | undefined;
+
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('refreshes through the OAuth endpoint and writes back to the selected credential file', async () => {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'ebay-auth-refresh-'));
+    const envPath = path.join(tempDir, '.env');
+    writeFileSync(envPath, 'EBAY_USER_REFRESH_TOKEN=integration_refresh_token\n', 'utf-8');
+    const credentialStore = new DotEnvCredentialStore(() => envPath);
+    const oauthClient = new EbayOAuthClient(config, credentialStore);
+
+    nock.disableNetConnect();
+    nock('https://api.sandbox.ebay.com')
+      .post('/identity/v1/oauth2/token', {
+        grant_type: 'refresh_token',
+        refresh_token: 'integration_refresh_token',
+      })
+      .reply(200, {
+        access_token: 'integration_access_token',
+        token_type: 'Bearer',
+        expires_in: 7200,
+      });
+    nock('https://api.sandbox.ebay.com')
+      .post('/identity/v1/oauth2/token', {
+        grant_type: 'client_credentials',
+        scope: 'https://api.ebay.com/oauth/api_scope',
+      })
+      .reply(200, {
+        access_token: 'integration_app_token',
+        token_type: 'Bearer',
+        expires_in: 7200,
+      });
+
+    await Effect.runPromise(oauthClient.initialize());
+
+    const persisted = dotenv.parse(readFileSync(envPath, 'utf-8'));
+    expect(persisted).toMatchObject({
+      EBAY_USER_ACCESS_TOKEN: 'integration_access_token',
+      EBAY_USER_REFRESH_TOKEN: 'integration_refresh_token',
+      EBAY_APP_ACCESS_TOKEN: 'integration_app_token',
+    });
+    await expect(Effect.runPromise(oauthClient.getAccessToken())).resolves.toBe(
+      'integration_access_token',
+    );
+    expect(nock.isDone()).toBe(true);
+  });
+});

--- a/tests/unit/auth/credentialSession.test.ts
+++ b/tests/unit/auth/credentialSession.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'os';
 import path from 'path';
 import dotenv from 'dotenv';
 import { Effect } from 'effect';
+import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   buildCredentialDisplay,
@@ -15,6 +16,7 @@ import {
   isTokenExpired,
   maskToken,
 } from '@/auth/credentialSession.js';
+import { CREDENTIAL_ENV_PATH, resolveCredentialEnvPath } from '@/config/credentialFile.js';
 
 describe('credential session', () => {
   let tempDir: string | undefined;
@@ -47,6 +49,15 @@ describe('credential session', () => {
       EBAY_USER_ACCESS_TOKEN: 'access',
       EBAY_USER_REFRESH_TOKEN: 'refresh',
     });
+  });
+
+  it('resolves the credential file from the installed package root (issue #157)', () => {
+    const installedModuleUrl = new URL('../../../build/config/credentialFile.js', import.meta.url);
+
+    expect(CREDENTIAL_ENV_PATH).toBe(fileURLToPath(new URL('../../../.env', import.meta.url)));
+    expect(resolveCredentialEnvPath(installedModuleUrl)).toBe(
+      fileURLToPath(new URL('../../.env', installedModuleUrl)),
+    );
   });
 
   it('preserves both keys under concurrent dual writes (issue #154)', async () => {

--- a/tests/unit/auth/oauth.test.ts
+++ b/tests/unit/auth/oauth.test.ts
@@ -7,6 +7,11 @@ import { mkdtempSync, promises as fsPromises, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { EbayOAuthClient, type EbayOAuthError } from '@/auth/oauth.js';
+import {
+  CredentialStoreError,
+  DotEnvCredentialStore,
+  type CredentialStore,
+} from '@/auth/credentialSession.js';
 import type { EbayConfig } from '@/types/ebay.js';
 import { mockOAuthTokenEndpoint, cleanupMocks } from '@tests/helpers/mockHttp.js';
 import process from 'node:process';
@@ -141,6 +146,36 @@ describe('EbayOAuthClient', () => {
 
       expect(oauthClient.hasUserTokens()).toBe(false);
     });
+
+    it('keeps a successfully refreshed user token when persistence fails (issue #157)', async () => {
+      const credentialStore: CredentialStore = {
+        write: () =>
+          Effect.fail(
+            new CredentialStoreError({
+              envPath: '/read-only/.env',
+              message: 'Failed to write credential updates to /read-only/.env',
+              cause: new Error('EACCES'),
+            }),
+          ),
+      };
+      config = { ...config, refreshToken: 'valid_refresh_token' };
+      oauthClient = new EbayOAuthClient(config, credentialStore);
+
+      mockOAuthTokenEndpoint('sandbox', {
+        access_token: 'refreshed_access_token',
+        token_type: 'Bearer',
+        expires_in: 7200,
+        refresh_token: 'valid_refresh_token',
+        refresh_token_expires_in: 47_304_000,
+      });
+
+      await initializeOAuthClient(oauthClient);
+
+      expect(oauthClient.hasUserTokens()).toBe(true);
+      await expect(Effect.runPromise(oauthClient.getAccessToken())).resolves.toBe(
+        'refreshed_access_token',
+      );
+    });
   });
 
   describe('hasUserTokens', () => {
@@ -196,6 +231,42 @@ describe('EbayOAuthClient', () => {
       const token = await getAccessToken(oauthClient);
 
       expect(token).toBe(newAccessToken);
+    });
+
+    it('uses a refreshed access token when only its persistence fails (issue #157)', async () => {
+      const credentialStore: CredentialStore = {
+        write: () =>
+          Effect.fail(
+            new CredentialStoreError({
+              envPath: '/read-only/.env',
+              message: 'Failed to write credential updates to /read-only/.env',
+              cause: new Error('EACCES'),
+            }),
+          ),
+      };
+      oauthClient = new EbayOAuthClient(config, credentialStore);
+      const expiredAccessToken = Date.now() - 1;
+      const validRefreshToken = Date.now() + 60_000;
+      await Effect.runPromise(
+        Effect.either(
+          oauthClient.setUserTokens(
+            'expired_access_token',
+            'valid_refresh_token',
+            expiredAccessToken,
+            validRefreshToken,
+          ),
+        ),
+      );
+      mockOAuthTokenEndpoint('sandbox', {
+        access_token: 'refreshed_access_token',
+        token_type: 'Bearer',
+        expires_in: 7200,
+      });
+
+      await expect(Effect.runPromise(oauthClient.getAccessToken())).resolves.toBe(
+        'refreshed_access_token',
+      );
+      expect(oauthClient.hasUserTokens()).toBe(true);
     });
 
     it('returns tagged error when both access and refresh tokens are expired', async () => {
@@ -401,6 +472,10 @@ describe('EbayOAuthClient', () => {
       originalCwd = process.cwd();
       tempDir = mkdtempSync(path.join(tmpdir(), 'ebay-oauth-persistence-'));
       process.chdir(tempDir);
+      oauthClient = new EbayOAuthClient(
+        config,
+        new DotEnvCredentialStore(() => path.join(tempDir, '.env')),
+      );
       writeFileSyncMock.mockClear();
     });
 
@@ -445,7 +520,10 @@ describe('EbayOAuthClient', () => {
     });
 
     it('refreshUserToken persists in-memory refresh token to .env even when eBay omits refresh_token (issue #114)', async () => {
-      oauthClient = new EbayOAuthClient({ ...config, refreshToken: 'stale_env_refresh' });
+      oauthClient = new EbayOAuthClient(
+        { ...config, refreshToken: 'stale_env_refresh' },
+        new DotEnvCredentialStore(() => path.join(tempDir, '.env')),
+      );
       await setUserTokens(oauthClient, 'old_access_token', 'in_memory_refresh');
       writeFileSyncMock.mockClear();
 
@@ -463,7 +541,10 @@ describe('EbayOAuthClient', () => {
     });
 
     it('refreshUserToken persists same refresh token when in-memory differs from env (issue #114, no rotation case)', async () => {
-      oauthClient = new EbayOAuthClient({ ...config, refreshToken: 'old_env_refresh' });
+      oauthClient = new EbayOAuthClient(
+        { ...config, refreshToken: 'old_env_refresh' },
+        new DotEnvCredentialStore(() => path.join(tempDir, '.env')),
+      );
       await setUserTokens(oauthClient, 'old_access_token', 'fresh_oauth_refresh');
       writeFileSyncMock.mockClear();
 
@@ -481,7 +562,10 @@ describe('EbayOAuthClient', () => {
     });
 
     it('refreshUserToken does NOT rewrite refresh token when in-memory matches env', async () => {
-      oauthClient = new EbayOAuthClient({ ...config, refreshToken: 'same_refresh' });
+      oauthClient = new EbayOAuthClient(
+        { ...config, refreshToken: 'same_refresh' },
+        new DotEnvCredentialStore(() => path.join(tempDir, '.env')),
+      );
       await fsPromises.writeFile(
         path.join(tempDir, '.env'),
         'EBAY_USER_REFRESH_TOKEN=same_refresh\nEBAY_USER_ACCESS_TOKEN=old_access\n',


### PR DESCRIPTION
## Summary

- resolve the OAuth credential file once from the installed package root and use it for both dotenv reads and token writes
- distinguish credential persistence failures from token endpoint failures so boot-time and on-demand refresh retain a valid refreshed in-memory session
- report persistence-only failures accurately and add a patch changeset
- cover installed-path resolution, boot/on-demand write failures, and the real refresh-to-filesystem path

Fixes #157

## Confidence

9/10 — focused regression coverage and the complete repository gate pass locally. The only initial red result was the repository's existing test-order dependency: `diagnosePackaging.test.ts` expects build output in a fresh worktree; building first and rerunning produced 1085/1085 passing unit tests.

## Test plan

- `npm run typecheck`
- `npm run check:ci`
- `npx vitest run tests/unit/auth/credentialSession.test.ts tests/unit/auth/oauth.test.ts` (36 passed)
- `npm run test:integration -- --run tests/integration/authTokenPersistence.test.ts` (1 passed)
- `npm run build`
- `npm test` (61 files, 1085 tests passed after build)
- `npm run test:integration` (3 files, 34 tests passed)
- UI/manual QA: N/A — non-UI OAuth persistence behavior


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves refreshed eBay OAuth tokens in memory when only credential persistence fails, and writes tokens to the package-root `.env` instead of the process working directory. Previously, a persistence error cleared tokens as if refresh failed; now the client keeps the valid refreshed token for the process and logs a persistence-specific error.

- Centralizes credential path in `CREDENTIAL_ENV_PATH` via `src/config/credentialFile.ts`; `DotEnvCredentialStore` now defaults to this path.
- Distinguishes `CredentialStoreError` from token endpoint errors; do not clear tokens on persistence-only failures.
- Aligns reads and writes to the same package-root `.env`; improves log messages.
- Adds unit and integration tests for installed-path resolution, boot/on-demand writes, and refresh-to-filesystem behavior; adds a patch changeset.

**Migration**
- Ensure the package-root `.env` is writable in your deployment. If you need a different location, provide a custom `CredentialStore` to `EbayOAuthClient`.

<sup>Written for commit 70649cbbd360e0f6ddd9afaa40a6385dab4f6ee1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YosefHayim/ebay-mcp/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

