### PR TITLE
fix(mcp): preserve structured write failures

### DIFF
--- a/.changeset/structured-write-errors.md
+++ b/.changeset/structured-write-errors.md
@@ -1,0 +1,5 @@
+---
+"ebay-mcp": patch
+---
+
+Preserve eBay HTTP status and structured error details in failed MCP write results while keeping empty-body writes as explicit successes.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -7,7 +7,7 @@ import { getErrorMessage } from '@/utils/errors.js';
 import { httpRequestEffect, isHttpError, type ResponseType } from '@/utils/http.js';
 import { isRecord } from '@/utils/typeGuards.js';
 import { apiLogger, logRequest, logResponse, logErrorResponse } from '@/utils/logger.js';
-import { Effect } from 'effect';
+import { Cause, Effect, Exit } from 'effect';
 
 /**
  * Per-request overrides accepted by the verb helpers ({@link EbayApiClient.get}
@@ -167,7 +167,13 @@ export class EbayApiClient {
     endpoint: string,
     options: EbayRequestOptions,
   ): Promise<T> {
-    return await Effect.runPromise(this.requestEffect<T>(method, endpoint, options));
+    // Preserve the typed request error for endpoint adapters. Plain runPromise
+    // rejects with a FiberFailure whose generic message hides eBay response data.
+    const exit = await Effect.runPromiseExit(this.requestEffect<T>(method, endpoint, options));
+    if (Exit.isSuccess(exit)) {
+      return exit.value;
+    }
+    throw Cause.squash(exit.cause);
   }
 
   /**

--- a/src/mcp/runtime.ts
+++ b/src/mcp/runtime.ts
@@ -12,7 +12,7 @@ import {
 } from '@/mcp/toolGating.js';
 import { buildUiToolResult, createUiBridge, type UiBridge } from '@/mcp/uiBridge.js';
 import { getToolEntries, type ToolEntry } from '@/tools/registry.js';
-import { getErrorMessage } from '@/utils/errors.js';
+import { getEbayErrorDetails } from '@/utils/errors.js';
 import { serverLogger, toolLogger } from '@/utils/logger.js';
 import { Effect } from 'effect';
 
@@ -58,13 +58,20 @@ function formatToolSuccess(result: unknown) {
 }
 
 function formatToolFailure(error: unknown) {
-  const errorMessage = getErrorMessage(error);
+  const { message, status, errors } = getEbayErrorDetails(error);
+  const payload: Record<string, unknown> = { error: message };
+  if (status !== undefined) {
+    payload.status = status;
+  }
+  if (errors !== undefined) {
+    payload.details = errors;
+  }
 
   return {
     content: [
       {
         type: 'text' as const,
-        text: JSON.stringify({ error: errorMessage }, null, 2),
+        text: JSON.stringify(payload, null, 2),
       },
     ],
     isError: true,
@@ -108,10 +115,10 @@ function registerTool(
               : formatToolSuccess(result);
           }),
           Effect.catchAll((error) => {
-            const errorMessage = getErrorMessage(error);
-
             if (logToolExecution) {
-              toolLogger.error(`Tool ${definition.name} failed`, { error: errorMessage });
+              toolLogger.error(`Tool ${definition.name} failed`, {
+                error: getEbayErrorDetails(error).message,
+              });
             }
 
             return Effect.succeed(formatToolFailure(error));

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,3 +1,6 @@
+import type { EbayClientRequestErrorKind } from '@/api/clientRequestError.js';
+import { Cause, Runtime } from 'effect';
+
 /**
  * Normalize an unknown thrown value into a human-readable message string.
  *
@@ -19,3 +22,117 @@
  */
 export const getErrorMessage = (error: unknown, fallback = 'Unknown error'): string =>
   error instanceof Error ? error.message : fallback;
+
+/** Structured eBay failure data recovered from an Effect error cause chain. */
+export interface EbayErrorDetails {
+  /** Most actionable human-readable failure message available. */
+  readonly message: string;
+  /** HTTP status returned by eBay, when the request reached eBay. */
+  readonly status?: number;
+  /** Raw eBay error entries, including identifiers and parameters. */
+  readonly errors?: unknown[];
+}
+
+interface EbayErrorAccumulator {
+  message: string;
+  status?: number;
+  errors?: unknown[];
+  messageLocked?: boolean;
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : undefined;
+
+const nextErrorNode = (node: Record<string, unknown>): unknown => {
+  const fiberCause = (node as Record<symbol, unknown>)[Runtime.FiberFailureCauseId];
+  if (fiberCause !== undefined) {
+    return Cause.squash(fiberCause as Cause.Cause<unknown>);
+  }
+  return node.cause;
+};
+
+const firstEbayErrorMessage = (errors: unknown[]): string | undefined => {
+  const first = asRecord(errors[0]);
+  if (!first) {
+    return;
+  }
+  const detail = first.longMessage ?? first.message;
+  return typeof detail === 'string' ? detail : undefined;
+};
+
+const KIND_IS_GUIDANCE: Record<EbayClientRequestErrorKind, boolean> = {
+  missingCredentials: true,
+  localRateLimit: true,
+  tokenAcquisition: true,
+  missingAccessToken: true,
+  tokenRefresh: true,
+  remoteRateLimit: true,
+  httpStatus: false,
+  transport: false,
+};
+
+const isGuidanceKind = (kind: string): boolean =>
+  Object.hasOwn(KIND_IS_GUIDANCE, kind) && KIND_IS_GUIDANCE[kind as EbayClientRequestErrorKind];
+
+const collectEbayErrorNode = (node: Record<string, unknown>, acc: EbayErrorAccumulator): void => {
+  const message =
+    typeof node.message === 'string' && node.message.length > 0 ? node.message : undefined;
+  if (message !== undefined && !acc.messageLocked) {
+    acc.message = message;
+    if (typeof node.kind === 'string' && isGuidanceKind(node.kind)) {
+      acc.messageLocked = true;
+    }
+  }
+  if (typeof node.status === 'number') {
+    acc.status = node.status;
+  }
+
+  const data = asRecord(node.data);
+  if (data && Array.isArray(data.errors)) {
+    acc.errors = data.errors;
+    const detail = firstEbayErrorMessage(data.errors);
+    if (detail && !acc.messageLocked) {
+      acc.message = detail;
+    }
+    return;
+  }
+
+  // Trading XML failures store their structured entries directly on `cause`.
+  if (acc.errors === undefined && Array.isArray(node.cause) && node.cause.length > 0) {
+    acc.errors = node.cause;
+  }
+};
+
+/**
+ * Recovers status, structured eBay errors, and the best message from nested
+ * tagged errors and Effect FiberFailures.
+ *
+ * @param error - Failure caught at an external boundary.
+ * @returns Structured details suitable for an MCP error result.
+ *
+ * @example
+ * ```ts
+ * const details = getEbayErrorDetails(error);
+ * ```
+ */
+export const getEbayErrorDetails = (error: unknown): EbayErrorDetails => {
+  const acc: EbayErrorAccumulator = { message: getErrorMessage(error) };
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+
+  while (current !== undefined && current !== null && !seen.has(current)) {
+    seen.add(current);
+    const node = asRecord(current);
+    if (!node) {
+      break;
+    }
+    collectEbayErrorNode(node, acc);
+    current = nextErrorNode(node);
+  }
+
+  return {
+    message: acc.message,
+    ...(acc.status === undefined ? {} : { status: acc.status }),
+    ...(acc.errors === undefined ? {} : { errors: acc.errors }),
+  };
+};

--- a/tests/integration/mcp/noContentResponses.test.ts
+++ b/tests/integration/mcp/noContentResponses.test.ts
@@ -1,0 +1,127 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { EbaySellerApi } from '@/api/index.js';
+import { createEbayMcpRuntime, type EbayMcpRuntime } from '@/mcp/runtime.js';
+import type { EbayConfig } from '@/types/ebay.js';
+import { cleanupMocks, mockEbayApiEndpoint, mockEbayApiError } from '@tests/helpers/mockHttp.js';
+import { Effect } from 'effect';
+import nock from 'nock';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockOAuthClient = {
+  getAccessToken: vi.fn(() => Effect.succeed('mock_access_token')),
+  initialize: vi.fn(() => Effect.succeed(undefined)),
+  isAuthenticated: vi.fn(() => true),
+};
+
+vi.mock('../../../src/auth/oauth.js', () => ({
+  EbayOAuthClient: vi.fn(function (this: unknown) {
+    return mockOAuthClient;
+  }),
+}));
+
+const inventoryItem = {
+  availability: { shipToLocationAvailability: { quantity: 1 } },
+  condition: 'NEW',
+  product: { title: 'MCP boundary test item' },
+};
+
+const parseTextPayload = (result: Awaited<ReturnType<Client['callTool']>>): unknown => {
+  const first = result.content[0];
+  if (!first || first.type !== 'text') {
+    throw new Error('Expected one MCP text content block');
+  }
+  return JSON.parse(first.text);
+};
+
+describe('204 responses at the MCP protocol boundary', () => {
+  let client: Client;
+  let runtime: EbayMcpRuntime;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeAll(async () => {
+    originalEnv = process.env;
+    process.env = { ...originalEnv, EBAY_MCP_TOOLS: 'inventory' };
+
+    const config: EbayConfig = {
+      clientId: 'test_client_id',
+      clientSecret: 'test_client_secret',
+      environment: 'sandbox',
+      redirectUri: 'https://localhost/callback',
+    };
+    runtime = createEbayMcpRuntime({
+      api: new EbaySellerApi(config),
+      serverConfig: { name: 'test-ebay-mcp', version: '0.0.0' },
+    });
+    await runtime.initializeApi();
+
+    client = new Client({ name: 'test-client', version: '0.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await runtime.server.connect(serverTransport);
+    await client.connect(clientTransport);
+  });
+
+  beforeEach(() => {
+    cleanupMocks();
+    nock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    cleanupMocks();
+    nock.enableNetConnect();
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await runtime.server.close();
+    process.env = originalEnv;
+  });
+
+  it('returns an explicit schema-valid success document for an eBay 204', async () => {
+    mockEbayApiEndpoint(
+      '/sell/inventory/v1/inventory_item/MCP-204',
+      'put',
+      'sandbox',
+      undefined,
+      204,
+    );
+
+    const result = await client.callTool({
+      name: 'ebay_create_or_replace_inventory_item',
+      arguments: { sku: 'MCP-204', body: inventoryItem },
+    });
+
+    expect(result.isError).not.toBe(true);
+    expect(parseTextPayload(result)).toEqual({ status: 'success' });
+  });
+
+  it('returns status and eBay details for a rejected write', async () => {
+    mockEbayApiError(
+      '/sell/inventory/v1/inventory_item/MCP-400',
+      'put',
+      'sandbox',
+      'Missing required field: availability',
+      400,
+    );
+
+    const result = await client.callTool({
+      name: 'ebay_create_or_replace_inventory_item',
+      arguments: { sku: 'MCP-400', body: inventoryItem },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseTextPayload(result)).toEqual({
+      error: 'Detailed error: Missing required field: availability',
+      status: 400,
+      details: [
+        {
+          errorId: 1001,
+          domain: 'API_INVENTORY',
+          category: 'REQUEST',
+          message: 'Missing required field: availability',
+          longMessage: 'Detailed error: Missing required field: availability',
+        },
+      ],
+    });
+  });
+});

--- a/tests/unit/api/errorDetails.test.ts
+++ b/tests/unit/api/errorDetails.test.ts
@@ -1,0 +1,60 @@
+import { EbayClientRequestError } from '@/api/clientRequestError.js';
+import { EbayApiError } from '@/api/shared/request.js';
+import { getEbayErrorDetails } from '@/utils/errors.js';
+import { Effect } from 'effect';
+import { describe, expect, it } from 'vitest';
+
+describe('getEbayErrorDetails', () => {
+  it('unwraps an Effect FiberFailure and returns REST status and details', async () => {
+    const eBayErrors = [
+      {
+        errorId: 2004,
+        longMessage: 'Invalid request payload',
+        parameters: [{ name: 'sku', value: 'BAD' }],
+      },
+    ];
+    const apiError = new EbayApiError({
+      method: 'PUT',
+      path: '/sell/inventory/v1/inventory_item/BAD',
+      cause: { status: 400, data: { errors: eBayErrors } },
+    });
+    let caught: unknown;
+
+    try {
+      await Effect.runPromise(Effect.fail(apiError));
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(getEbayErrorDetails(caught)).toEqual({
+      message: 'Invalid request payload',
+      status: 400,
+      errors: eBayErrors,
+    });
+  });
+
+  it('preserves remediation guidance while retaining raw error details', () => {
+    const eBayErrors = [{ errorId: 1, longMessage: 'raw rate-limit response' }];
+    const error = new EbayClientRequestError({
+      kind: 'remoteRateLimit',
+      method: 'GET',
+      url: 'https://api.ebay.com/x',
+      message: 'eBay API rate limit exceeded. Retry after 12 seconds.',
+      status: 429,
+      cause: { status: 429, data: { errors: eBayErrors } },
+    });
+
+    expect(getEbayErrorDetails(error)).toEqual({
+      message: 'eBay API rate limit exceeded. Retry after 12 seconds.',
+      status: 429,
+      errors: eBayErrors,
+    });
+  });
+
+  it('terminates a cyclic cause chain', () => {
+    const cyclic: Record<string, unknown> = { message: 'cyclic failure' };
+    cyclic.cause = cyclic;
+
+    expect(getEbayErrorDetails(cyclic)).toEqual({ message: 'cyclic failure' });
+  });
+});

--- a/tests/unit/mcp/runtime.test.ts
+++ b/tests/unit/mcp/runtime.test.ts
@@ -103,4 +103,52 @@ describe('MCP runtime', () => {
     expect(result).not.toMatchObject({ isError: true });
     expect(JSON.parse(result.content[0]!.text)).toEqual({ status: 'success' });
   });
+
+  it('preserves structured eBay details for a failed registered tool call', async () => {
+    const { createEbayMcpRuntime } = await import('@/mcp/runtime.js');
+    const { EbayApiError } = await import('@/api/shared/request.js');
+    const eBayErrors = [
+      {
+        errorId: 25_709,
+        message: 'Invalid header',
+        longMessage: 'Invalid value for header Accept-Language',
+        parameters: [{ name: 'Accept-Language', value: '*' }],
+      },
+    ];
+    const createInventoryLocation = vi.fn(() =>
+      Effect.fail(
+        new EbayApiError({
+          method: 'POST',
+          path: '/sell/inventory/v1/location/WH1',
+          cause: { status: 400, data: { errors: eBayErrors } },
+        }),
+      ),
+    );
+    const api = {
+      initialize: vi.fn(() => Effect.succeed(undefined)),
+      inventory: { createInventoryLocation },
+    };
+
+    createEbayMcpRuntime({
+      api: api as never,
+      serverConfig: { name: 'test-mcp', version: '0.0.0' },
+    });
+
+    const createLocationCall = [...mcpMock.registerTool.mock.calls]
+      .reverse()
+      .find(([name]) => name === 'ebay_create_inventory_location');
+    const handler = createLocationCall?.[2] as (args: Record<string, unknown>) => Promise<{
+      content: Array<{ type: string; text: string }>;
+      isError?: boolean;
+    }>;
+    const result = await handler({ merchantLocationKey: 'WH1', body: {} });
+    const payload = JSON.parse(result.content[0]?.text ?? '{}');
+
+    expect(result.isError).toBe(true);
+    expect(payload).toEqual({
+      error: 'Invalid value for header Accept-Language',
+      status: 400,
+      details: eBayErrors,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- keep the explicit `{ "status": "success" }` response already used for successful 204/empty-body writes
- unwrap Effect failure causes so genuine eBay failures retain their HTTP status and original structured `errors[]`
- preserve actionable remediation messages such as rate-limit guidance
- add an in-memory MCP protocol test backed by hermetic eBay HTTP mocks for both 204 success and 400 failure

Fixes #159

## Confidence

**9/10** — covered at utility, registered-tool, real MCP transport, and HTTP-mocked integration boundaries. UI QA is N/A because this is an MCP text-result/API behavior change.

## Test plan

- `pnpm exec vitest run tests/unit/api/errorDetails.test.ts tests/unit/mcp/runtime.test.ts`
- `pnpm exec vitest run --config vitest.integration.config.cts tests/integration/mcp/noContentResponses.test.ts`
- `npm run typecheck`
- `npm run check:ci`
- `npm run build`
- `npm test` — 1,086 passed
- `npm run test:integration` — 35 passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves eBay HTTP status and structured `errors[]` for failed MCP writes while keeping explicit success for 204/no-content writes. Previously, failures surfaced as generic FiberFailures; now MCP error payloads include an actionable message, `status`, and `details`.

- Review notes:
  - In `src/api/client.ts`, unwrap Effect exits with `runPromiseExit` and rethrow typed errors via `Cause.squash` to retain eBay response data.
  - Add `getEbayErrorDetails` in `src/utils/errors.ts` to walk cause chains (including FiberFailures), preserve remediation guidance (e.g., rate limits), and extract `status` and raw eBay `errors[]`.
  - Update `src/mcp/runtime.ts` to emit `{ error, status?, details? }` in MCP text results and to log the recovered message.
  - Add hermetic tests: in-memory MCP transport covering 204 success and 400 failure, plus unit tests for error extraction and MCP tool failures.

<sup>Written for commit 853ea1905769ca7be52e8bce82cf385fa231fba7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YosefHayim/ebay-mcp/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

