### PR TITLE
chore(release): recover v1.15.0 version commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ebay-mcp",
-  "version": "1.14.3",
+  "version": "1.15.0",
   "description": "Model Context Protocol (MCP) server that exposes 100% of eBay's Sell APIs (299 tools across 270 endpoints) to AI assistants like Claude, Cursor, and Cline, covering inventory, order fulfillment, marketing, analytics, and developer tools with OAuth authentication and refresh-token support.",
   "type": "module",
   "main": "build/index.js",


### PR DESCRIPTION
## Summary

- land the automation-created `1.15.0` package version commit on protected `main`
- preserve the already-pushed immutable `v1.15.0` tag
- unblock manual GitHub Release creation and trusted npm publication

## Context

The Release workflow passed typecheck, 1,103 unit tests, and build, then created commit `c9b83ab` and tag `v1.15.0`. Branch protection rejected the direct bot push to `main` because a fresh CI Gate was required, while the tag push succeeded. This PR carries only the one-line package version change through the protected-branch path.

## Test plan

- [x] Diff from merged main is only `package.json` version `1.14.3` to `1.15.0`
- [ ] Hosted CI Gate

## Release safety

- `no-release` label prevents a second automatic release attempt on merge
- existing tag is preserved; no remote tag or branch deletion

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers the automation-created v1.15.0 version bump on protected main so the tag `v1.15.0` matches `main` and we can proceed with manual GitHub Release and trusted npm publish. The bot push to main was blocked; this merges the one-line version change while preserving the existing tag.

**Review and rollout**
- Update is only `package.json` version: 1.14.3 → 1.15.0 for `ebay-mcp`.
- Let CI Gate run and merge only if green; the `no-release` label prevents a second automatic release.
- Do not retag or delete; keep `v1.15.0` as-is.
- After merge: create the GitHub Release from `v1.15.0` and publish to npm.

<sup>Written for commit c9b83abe2df56fed39d6043ce639cf3609b0b5c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YosefHayim/ebay-mcp/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

